### PR TITLE
.NET 10 upgrade

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,93 @@
+root = true
+
+# =========================================================
+# GLOBAL DEFAULTS (apply to all files)
+# =========================================================
+[*]
+indent_style = space
+indent_size = 4
+tab_width = 4
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+# =========================================================
+# C# (Visual Studio, .NET APIs, microservices)
+# =========================================================
+[*.cs]
+indent_style = space
+indent_size = 4
+dotnet_sort_system_directives_first = true
+csharp_new_line_before_open_brace = all
+
+# =========================================================
+# Java (Spring Boot microservices, shared libs)
+# =========================================================
+[*.java]
+indent_style = space
+indent_size = 4
+
+# =========================================================
+# Python (ML scripts, utilities, automation)
+# =========================================================
+[*.py]
+indent_style = space
+indent_size = 4
+max_line_length = 120
+
+# =========================================================
+# JavaScript / TypeScript (React, Angular)
+# =========================================================
+[*.js]
+indent_size = 2
+
+[*.jsx]
+indent_size = 2
+
+[*.ts]
+indent_size = 2
+
+[*.tsx]
+indent_size = 2
+
+# =========================================================
+# HTML / CSS / SCSS (UI templates)
+# =========================================================
+[*.html]
+indent_size = 2
+
+[*.css]
+indent_size = 2
+
+[*.scss]
+indent_size = 2
+
+# =========================================================
+# JSON / YAML / XML (configs, pipelines, manifests)
+# =========================================================
+[*.json]
+indent_size = 2
+
+[*.yml]
+indent_size = 2
+
+[*.yaml]
+indent_size = 2
+
+[*.xml]
+indent_size = 2
+
+# =========================================================
+# Dockerfiles
+# =========================================================
+[Dockerfile]
+indent_style = space
+indent_size = 4
+
+# =========================================================
+# Shell scripts
+# =========================================================
+[*.sh]
+indent_style = space
+indent_size = 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+  merge_group:
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+    env:
+      DOTNET_NOLOGO: true
+      DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+          cache: true
+          cache-dependency-path: |
+            **/*.csproj
+            **/*.fsproj
+            **/*.props
+            **/*.targets
+            **/nuget.config
+            global.json
+            Directory.Packages.props
+
+      - name: dotnet info
+        run: dotnet --info
+
+      - name: Restore
+        run: dotnet restore Bitai.Ldap.Helper.sln
+
+      - name: Build
+        run: dotnet build Bitai.Ldap.Helper.sln --configuration Release --no-restore
+
+      - name: Test
+        run: dotnet test Bitai.Ldap.Helper.sln --configuration Release --no-build --no-restore --verbosity normal

--- a/Bitai.Ldap.Helper.sln
+++ b/Bitai.Ldap.Helper.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.4.33213.308
+# Visual Studio Version 18
+VisualStudioVersion = 18.6.11822.322 stable
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Bitai.LDAPHelper.DTO", "src\Bitai.LDAPHelper.DTO\Bitai.LDAPHelper.DTO.csproj", "{2386A126-F237-43FD-9A7C-FDF6718ACAD7}"
 EndProject

--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ Enables quick and secure validation of user credentials on the LDAP/AD server.
 
 ### 👤 2. Account Management (`AccountManager`)
 Simplifies user provisioning and lifecycle management within Active Directory.
-- **Create User Accounts** (`CreateUserAccountForMsAD`): Provision new Active Directory entries (`LDAPMsADUserAccount`) with extensive attribute mappings (such as UPN, sAMAccountName, unicodePwd, department, memberOf, object classes, and user control flags).
+- **Create MS AD User Accounts** (`CreateUserAccountForMsAD`): Provision new Active Directory entries (`LDAPMsADUserAccount`) with extensive attribute mappings (such as UPN, sAMAccountName, unicodePwd, department, memberOf, object classes, and user control flags).
 - **Set/Change Passwords** (`SetUserAccountPasswordForMsAD`): Safe password replacement utilizing secure Unicode encoding. It can optionally test immediate post-update authentication.
-- **Disable Accounts** (`DisableUserAccountForMsAD`): Securely disables accounts by updating the `userAccountControl` attribute with the `ACCOUNTDISABLE` flag, dynamically preserving all other existing account name flags to prevent unintended configuration loss.
-- **Remove Accounts** (`RemoveUserAccountForMsAD`): Permanently deletes user entries from the directory service.
+- **Disable MS AD Accounts** (`DisableUserAccountForMsAD`): Securely disables accounts by updating the `userAccountControl` attribute with the `ACCOUNTDISABLE` flag, dynamically preserving all other existing account flags to prevent unintended configuration loss.
+- **Remove MS AD Accounts** (`RemoveUserAccountForMsAD`): Permanently deletes user entries from the directory service.
 
 ### 🔍 3. Directory Searching (`Searcher`)
 Facilitates fast, flexible searching using highly customizable LDAP search configurations.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Bitai.LDAPHelper ![Logo](resources/hierarchy_32.png)
 
-A high-performance **.NET 8.0** library wrapping **Novell.Directory.Ldap.NETStandard** functionality to interact with LDAP-compliant Directory Services (such as Microsoft Active Directory). It simplifies operations like searching, authenticating users, and creating, modifying, disabling, or deleting accounts.
+A high-performance library wrapping **Novell.Directory.Ldap.NETStandard** functionality to interact with LDAP-compliant Directory Services (such as Microsoft Active Directory). It simplifies operations like searching, authenticating users, and creating, modifying, disabling, or deleting accounts.
 
 This library is a key component of the [Bitai.LDAPWebApi](https://github.com/bitai-cs/LDAPWebApi) solution ecosystem.
 
@@ -12,7 +12,7 @@ The library is organized into specialized helper classes targeting specific dire
 
 ### 🛡️ 1. Authentication (`Authenticator`)
 Enables quick and secure validation of user credentials on the LDAP/AD server.
-- Supports both **User Distinguished Name (DN)** (`LDAPDistinguishedNameCredential`) and **Domain Account Name** (`LDAPDomainAccountCredential`) credential structures.
+- Supports both **User Distinguished Name (DN)** (`LDAPDistinguishedNameCredential`) and **Domain Username** (`LDAPDomainAccountCredential`) credential structures.
 - Provides a simple authentication bind check (`AuthenticateAsync(credential)`).
 - Provides a comprehensive, pre-validated authentication workflow that first searches the user entry in Active Directory to ensure uniqueness and validity before attempting the bind (`AuthenticateAsync(credential, searchLimits, searchCredential)`).
 
@@ -20,7 +20,7 @@ Enables quick and secure validation of user credentials on the LDAP/AD server.
 Simplifies user provisioning and lifecycle management within Active Directory.
 - **Create User Accounts** (`CreateUserAccountForMsAD`): Provision new Active Directory entries (`LDAPMsADUserAccount`) with extensive attribute mappings (such as UPN, sAMAccountName, unicodePwd, department, memberOf, object classes, and user control flags).
 - **Set/Change Passwords** (`SetUserAccountPasswordForMsAD`): Safe password replacement utilizing secure Unicode encoding. It can optionally test immediate post-update authentication.
-- **Disable Accounts** (`DisableUserAccountForMsAD`): Securely disables accounts by updating the `userAccountControl` attribute with the `ACCOUNTDISABLE` flag, dynamically preserving all other existing account flags to prevent unintended configuration loss.
+- **Disable Accounts** (`DisableUserAccountForMsAD`): Securely disables accounts by updating the `userAccountControl` attribute with the `ACCOUNTDISABLE` flag, dynamically preserving all other existing account name flags to prevent unintended configuration loss.
 - **Remove Accounts** (`RemoveUserAccountForMsAD`): Permanently deletes user entries from the directory service.
 
 ### 🔍 3. Directory Searching (`Searcher`)
@@ -49,7 +49,7 @@ The solution `LDAP Helper Libraries.sln` consists of the following projects:
 
 ## ⚙️ Requirements & Dependencies
 
-- **.NET 8.0 SDK** or higher.
+- **.NET 10 SDK** or higher.
 - **Novell.Directory.Ldap.NETStandard** (v4.0.0+) package dependency.
 
 ---

--- a/demo/Bitai.LDAPHelper.Demo/Bitai.LDAPHelper.Demo.csproj
+++ b/demo/Bitai.LDAPHelper.Demo/Bitai.LDAPHelper.Demo.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<RootNamespace>Bitai.LDAPHelper.Demo</RootNamespace>
 		<Authors>Viko Bastidas (BITAI)</Authors>
 		<Company>BITAI</Company>
@@ -10,17 +10,17 @@
 		<Copyright>© 2026 BITAI. All rights reserved.</Copyright>
 		<PackageId>Bitai.Bitai.LDAPHelper.Demo</PackageId>
 		<PackageIcon>hierarchy_32.png</PackageIcon>
-		<Version>8.6.0</Version>
-		<AssemblyVersion>8.6.0.0</AssemblyVersion>
-		<FileVersion>8.6.0.0</FileVersion>
-		<PackageReleaseNotes>.NET 8 ready</PackageReleaseNotes>
+		<Version>10.0.0</Version>
+		<AssemblyVersion>10.0.0</AssemblyVersion>
+		<FileVersion>10.0.0</FileVersion>
+		<PackageReleaseNotes>.NET 10 ready</PackageReleaseNotes>
 		<PackageTags>ldap-ad-identity-auth-openid-oauth-security</PackageTags>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.3" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
-		<PackageReference Include="Serilog" Version="2.12.0" />
-		<PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.8" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.8" />
+		<PackageReference Include="Serilog" Version="4.3.1" />
+		<PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
 		<PackageReference Include="Spectre.Console" Version="0.55.2" />
 	</ItemGroup>
 	<ItemGroup>

--- a/demo/Bitai.LDAPHelper.Demo/Program.DemoMethods.cs
+++ b/demo/Bitai.LDAPHelper.Demo/Program.DemoMethods.cs
@@ -23,7 +23,7 @@ public partial class Program
 
         var domainAccountCredentialParts = domainAccountCredential.Split(new char[] { '\\' });
 
-        Log.Information("Authenticating account name...");
+        Log.Information("Authenticating domain username...");
         var authenticationResult = await authenticator.AuthenticateAsync(
             new LDAPDomainAccountCredential(domainAccountCredentialParts[0], domainAccountCredentialParts[1], accountPassword), 
             context.RequestLabel);
@@ -33,9 +33,9 @@ public partial class Program
             Log.Information("{@model}", authenticationResult);
 
             if (authenticationResult.IsAuthenticated)
-                Log.Information("Account name authenticated.");
+                Log.Information("Username authenticated.");
             else
-                Log.Warning("Account name NOT authenticated.");
+                Log.Warning("Username NOT authenticated.");
         }
         else
         {
@@ -58,7 +58,7 @@ public partial class Program
 
         var domainAccountCredentialParts = domainAccountCredential.Split(new char[] { '\\' });
 
-        Log.Information("Authenticating account name with account validation...");
+        Log.Information("Authenticating username with account validation...");
         var authenticationResult = await authenticator.AuthenticateAsync(
             new LDAPDomainAccountCredential(domainAccountCredentialParts[0], domainAccountCredentialParts[1], accountPassword),
             context.GetSearchLimits(),
@@ -70,9 +70,9 @@ public partial class Program
             Log.Information("{@model}", authenticationResult);
 
             if (authenticationResult.IsAuthenticated)
-                Log.Information("Account name authenticated.");
+                Log.Information("Username authenticated.");
             else
-                Log.Warning("Account name NOT authenticated.");
+                Log.Warning("Username NOT authenticated.");
         }
         else
         {

--- a/src/Bitai.LDAPHelper.DTO/Bitai.LDAPHelper.DTO.csproj
+++ b/src/Bitai.LDAPHelper.DTO/Bitai.LDAPHelper.DTO.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-    <AssemblyVersion>8.6.0.0</AssemblyVersion>
-    <FileVersion>8.6.0.0</FileVersion>
-    <Version>8.6.0</Version>
+    <TargetFramework>net10.0</TargetFramework>
+    <AssemblyVersion>10.0.0</AssemblyVersion>
+    <FileVersion>10.0.0</FileVersion>
+    <Version>10.0.0</Version>
     <AssemblyName>Bitai.LDAPHelper.DTO</AssemblyName>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Viko Bastidas (BITAI)</Authors>
@@ -21,7 +21,7 @@
     <RepositoryType>GitHub</RepositoryType>
     <PackageTags>ldap, authentication, directory, helper</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <PackageReleaseNotes>.NET 8 ready</PackageReleaseNotes>
+    <PackageReleaseNotes>.NET 10 ready</PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Bitai.LDAPHelper.DTO/LDAPDistinguishedNameCredential.cs
+++ b/src/Bitai.LDAPHelper.DTO/LDAPDistinguishedNameCredential.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -32,7 +32,7 @@ namespace Bitai.LDAPHelper.DTO
 		public LDAPDistinguishedNameCredential(string distinguishedName, string password)
 		{
 			if (string.IsNullOrEmpty(distinguishedName))
-				throw new InvalidOperationException("The account name must be specified.");
+				throw new InvalidOperationException("A distinguished name is required: the account’s DN must be specified.");
 
 			DistinguishedName = distinguishedName;
 			Password = password;

--- a/src/Bitai.LDAPHelper.DTO/LDAPDomainAccountCredential.cs
+++ b/src/Bitai.LDAPHelper.DTO/LDAPDomainAccountCredential.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.Serialization;
@@ -28,21 +28,21 @@ namespace Bitai.LDAPHelper.DTO
 		/// <summary>
 		/// Constructor
 		/// </summary>
-		/// <param name="domainName">Domain name.</param>
-		/// <param name="accountName">Account name.</param>
+		/// <param name="domainName">Domain name</param>
+		/// <param name="username">Username</param>
 		/// <param name="domainAccountPassword">Account password.</param>
 		/// <exception cref="InvalidOperationException">Constructor exception.</exception>
-		public LDAPDomainAccountCredential(string domainName, string accountName, string domainAccountPassword)
+		public LDAPDomainAccountCredential(string domainName, string username, string domainAccountPassword)
 		{
 			if (string.IsNullOrEmpty(domainName))
 				throw new InvalidOperationException("The domain name must be specified.");
 
-			if (string.IsNullOrEmpty(accountName))
-				throw new InvalidOperationException("The account name must be specified.");
+			if (string.IsNullOrEmpty(username))
+				throw new InvalidOperationException("The username must be specified.");
 
 
 			DomainName = domainName;
-			AccountName = accountName;
+			AccountName = username;
 			DomainAccountPassword = domainAccountPassword;
 		}
 

--- a/src/Bitai.LDAPHelper/AccountManager.cs
+++ b/src/Bitai.LDAPHelper/AccountManager.cs
@@ -30,11 +30,11 @@ namespace Bitai.LDAPHelper
 		}
 
 		/// <summary>
-		/// Create a user account in MS Active Directory service
+		/// Create a username in MS Active Directory service
 		/// https://www.rlmueller.net/Name_Attributes.htm
 		/// </summary>
 		/// <param name="newUserAccount"><see cref="LDAPMsADUserAccount"/></param>
-		/// <param name="distinguishedNameOfContainer">DN of the container in which the user account will be created.</param>
+		/// <param name="distinguishedNameOfContainer">DN of the container in which the username will be created.</param>
 		/// <param name="requestLabel">Optional tag to mark the request and/or response.</param>
 		/// <returns>A Task of <see cref="LDAPCreateMsADUserAccountResult"/></returns>
 		public async Task<LDAPCreateMsADUserAccountResult> CreateUserAccountForMsAD(LDAPMsADUserAccount newUserAccount, string requestLabel = null)
@@ -58,7 +58,7 @@ namespace Bitai.LDAPHelper
 					throw new InvalidOperationException($"{nameof(newUserAccount.ObjectClass)} is required.");
 				#endregion
 
-				//Generate user account DistinguishedName LDAP attribute
+				//Generate username DistinguishedName LDAP attribute
 				InitializeMissingMsADUserAccountDN(newUserAccount);
 
                 using (var ldapConnection = await GetLdapConnection(this.ConnectionInfo, this.DomainAccountCredential)) {
@@ -113,18 +113,18 @@ namespace Bitai.LDAPHelper
                     }                   
                     #endregion
 
-                    //Add new user account entry to the directory
+                    //Add new username entry to the directory
                     await ldapConnection.AddEntryAsync(newUserAccount.DistinguishedName, attributeSet);                    
                 }
 
 				return new LDAPCreateMsADUserAccountResult(newUserAccount.SecureClone(), requestLabel)
 				{
-					OperationMessage = $"User account created at {newUserAccount.DistinguishedName} with {EntryAttribute.sAMAccountName.ToString()}: {newUserAccount.SAMAccountName}"
+					OperationMessage = $"Account name created at {newUserAccount.DistinguishedName} with {EntryAttribute.sAMAccountName.ToString()}: {newUserAccount.SAMAccountName}"
 				};
 			}
 			catch (Exception ex)
 			{
-				return new LDAPCreateMsADUserAccountResult("Error creating user account.", ex, requestLabel)
+				return new LDAPCreateMsADUserAccountResult("Error creating username.", ex, requestLabel)
 				{
 					UserAccount = newUserAccount.SecureClone()
 				};
@@ -132,18 +132,18 @@ namespace Bitai.LDAPHelper
 		}
 
         /// <summary>
-        /// Set a password for a user account in MS Active Directory service. This method will verify the authenticity of the user account by its distinguished name before trying to set the password. If the user account is not valid, the operation will not be attempted and an error will be returned.
+        /// Set a password for a username in MS Active Directory service. This method will verify the authenticity of the username by its distinguished name before trying to set the password. If the username is not valid, the operation will not be attempted and an error will be returned.
         /// </summary>
         /// <param name="credential"><see cref="LDAPDistinguishedNameCredential"/></param>
         /// <param name="requestLabel">Optional tag to mark the request and/or response.</param>
-        /// <param name="postUpdateTestAuthentication">True if the account will be tested to be able to authenticate with the new password. False if only the password will be assigned, authentication will not be tested.</param>
+        /// <param name="postUpdateTestAuthentication">True if the account name will be tested to verify authentication with the new password. False if the password will simply be assigned and authentication will not be tested.</param>
         /// <returns></returns>
         public async Task<LDAPPasswordUpdateResult> SetUserAccountPasswordForMsAD(DTO.LDAPDistinguishedNameCredential credential, string requestLabel = null, bool postUpdateTestAuthentication = true)
 		{
 			try
 			{
 				if (string.IsNullOrEmpty(credential.DistinguishedName))
-					throw new ArgumentNullException("The distinguished name of the user account is required.");
+					throw new ArgumentNullException("The distinguished name of the username is required.");
 
 				if (string.IsNullOrEmpty(credential.Password))
 					throw new ArgumentNullException($"The password to be assigned is required.");
@@ -203,9 +203,9 @@ namespace Bitai.LDAPHelper
         }
 
         /// <summary>
-        /// Remove a user account from MS Active Directory service. This method will verify the authenticity of the user account by its distinguished name before trying to remove it. If the user account is not valid, the operation will not be attempted and an error will be returned.
+        /// Remove a username from MS Active Directory service. This method will verify the authenticity of the username by its distinguished name before trying to remove it. If the username is not valid, the operation will not be attempted and an error will be returned.
         /// </summary>
-        /// <param name="distinguishedName">User account distinguished name</param>
+        /// <param name="distinguishedName">Distinguished name of the username</param>
         /// <param name="requestLabel">Optional tag to mark the request and/or response.</param>
         /// <returns><see cref="LDAPDisableUserAccountOperationResult"/></returns>
         public async Task<LDAPDisableUserAccountOperationResult> DisableUserAccountForMsAD(string distinguishedName, string requestLabel)
@@ -218,11 +218,11 @@ namespace Bitai.LDAPHelper
 				var entry = await verifyUserAccountAuthenticity(distinguishedName, requestLabel);
 
                 using (var ldapConnection = await GetLdapConnection(this.ConnectionInfo, this.DomainAccountCredential)) {
-                    //To disable a user account in MS AD, the userAccountControl attribute needs to be set with the appropriate flags. The flag for disabling an account is ACCOUNTDISABLE (0x0002). However, when setting the userAccountControl attribute, it is important to preserve the existing flags that are set for the account, and only add the ACCOUNTDISABLE flag without removing any of the existing flags. This is because other flags may be set for the account that are necessary for its proper functioning, and removing them could cause unintended consequences. Therefore, when disabling a user account, you should retrieve the current value of the userAccountControl attribute, add the ACCOUNTDISABLE flag to it, and then update the attribute with the new value that includes both the existing flags and the ACCOUNTDISABLE flag.
+                    //To disable an account name in MS AD, the userAccountControl attribute needs to be set with the appropriate flags. The flag for disabling an account name is ACCOUNTDISABLE (0x0002). However, when setting the userAccountControl attribute, it is important to preserve the existing flags that are set for the account, and only add the ACCOUNTDISABLE flag without removing any of the existing flags. This is because other flags may be set for the account name that are necessary for its proper functioning, and removing them could cause unintended consequences. Therefore, when disabling a username, you should retrieve the current value of the userAccountControl attribute, add the ACCOUNTDISABLE flag to it, and then update the attribute with the new value that includes both the existing flags and the ACCOUNTDISABLE flag.
                     UserAccountControlFlagsForMsAD userAccountControlFlags = UserAccountControlFlagsForMsAD.NORMAL_ACCOUNT | UserAccountControlFlagsForMsAD.ACCOUNTDISABLE;
                     //var userAccountControlAttribute = new LdapAttribute(DTO.EntryAttribute.userAccountControl.ToString(), ((int)userAccountControlFlags).ToString());
 
-                    //Create modification request to disable the account by setting the userAccountControl attribute with the appropriate flags
+                    //Create modification request to disable the account name by setting the userAccountControl attribute with the appropriate flags
                     var modification = ldapConnection.CreateModification(LdapModificationType.Replace, EntryAttribute.userAccountControl.ToString(),
                         ((int)userAccountControlFlags).ToString());
                     //var userAccountControlModification = new LdapModification(LdapModification.Replace, userAccountControlAttribute);
@@ -234,7 +234,7 @@ namespace Bitai.LDAPHelper
 
 				return new DTO.LDAPDisableUserAccountOperationResult(requestLabel)
 				{
-					OperationMessage = $"User account {entry.samAccountName} has been disabled."
+					OperationMessage = $"Username {entry.samAccountName} has been disabled."
 				};
 			}
             catch (Bitai.LDAPHelper.EntryNotFoundException ex) {
@@ -242,14 +242,14 @@ namespace Bitai.LDAPHelper
             }
             catch (Exception ex)
 			{
-				return new LDAPDisableUserAccountOperationResult($"Error trying to disable user account with DN: {distinguishedName}", ex, requestLabel);
+				return new LDAPDisableUserAccountOperationResult($"Error trying to disable username with DN: {distinguishedName}", ex, requestLabel);
 			}
 		}
 
         /// <summary>
-        /// Remove a user account in MS Active Directory service. This operation will permanently delete the user account entry from the directory, so it should be used with caution.
+        /// Remove a username in MS Active Directory service. This operation will permanently delete the username entry from the directory, so it should be used with caution.
         /// </summary>
-        /// <param name="distinguishedName">User account distinguished name.</param>
+        /// <param name="distinguishedName">Distinguished name of the username</param>
         /// <param name="requestLabel">Optional tag to mark the request and/or response.</param>
         /// <returns><see cref="LDAPRemoveMsADUserAccountResult"/></returns>
         public async Task<LDAPRemoveMsADUserAccountResult> RemoveUserAccountForMsAD(string distinguishedName, string requestLabel = null)
@@ -257,20 +257,20 @@ namespace Bitai.LDAPHelper
 			try
 			{
 				if (string.IsNullOrEmpty(distinguishedName))
-					throw new ArgumentNullException("The DN of the account to be removed must be provided.");
+					throw new ArgumentNullException("The distinguished name of the username to remove must be provided.");
 
 				var entry = await verifyUserAccountAuthenticity(distinguishedName, requestLabel);
 
 				using (var ldapConnection = await GetLdapConnection(this.ConnectionInfo, this.DomainAccountCredential))
 				{
-                    //To remove a user account from MS AD, the user account entry needs to be deleted from the directory. This operation will permanently delete the user account entry, so it should be used with caution.
+                    //To remove a username from MS AD, the username entry needs to be deleted from the directory. This operation will permanently delete the username entry, so it should be used with caution.
                     await ldapConnection.DeleteEntryAsync(entry.distinguishedName);
                     //await ldapConnection.DeleteAsync(entry.distinguishedName);
                 }
 
 				return new LDAPRemoveMsADUserAccountResult(requestLabel)
 				{
-					OperationMessage = $"The user account {entry.samAccountName} has been successfully removed."
+					OperationMessage = $"The username {entry.samAccountName} has been successfully removed."
 				};
 			}
             catch (Bitai.LDAPHelper.EntryNotFoundException ex) {
@@ -278,7 +278,7 @@ namespace Bitai.LDAPHelper
             }
             catch (Exception ex)
 			{
-				return new LDAPRemoveMsADUserAccountResult($"Error trying to remove user account with DN: {distinguishedName}", ex, requestLabel);
+				return new LDAPRemoveMsADUserAccountResult($"Error trying to remove username with DN: {distinguishedName}", ex, requestLabel);
 			}
 		}
 
@@ -307,7 +307,7 @@ namespace Bitai.LDAPHelper
 			var entry = searchResult.Entries.Single();
 
 			if (!entry.objectClass.Contains("user"))
-				throw new InvalidOperationException($"DN {distinguishedName} is not a user account.");
+				throw new InvalidOperationException($"DN {distinguishedName} is not a username.");
 
 			return entry;
 		}

--- a/src/Bitai.LDAPHelper/AccountManager.cs
+++ b/src/Bitai.LDAPHelper/AccountManager.cs
@@ -119,7 +119,7 @@ namespace Bitai.LDAPHelper
 
 				return new LDAPCreateMsADUserAccountResult(newUserAccount.SecureClone(), requestLabel)
 				{
-					OperationMessage = $"Account name created at {newUserAccount.DistinguishedName} with {EntryAttribute.sAMAccountName.ToString()}: {newUserAccount.SAMAccountName}"
+					OperationMessage = $"MS AD user account created at {newUserAccount.DistinguishedName} with {EntryAttribute.sAMAccountName.ToString()}: {newUserAccount.SAMAccountName}"
 				};
 			}
 			catch (Exception ex)
@@ -136,7 +136,7 @@ namespace Bitai.LDAPHelper
         /// </summary>
         /// <param name="credential"><see cref="LDAPDistinguishedNameCredential"/></param>
         /// <param name="requestLabel">Optional tag to mark the request and/or response.</param>
-        /// <param name="postUpdateTestAuthentication">True if the account name will be tested to verify authentication with the new password. False if the password will simply be assigned and authentication will not be tested.</param>
+        /// <param name="postUpdateTestAuthentication">True if the MS AD user account will be tested to verify authentication with the new password. False if the password will simply be assigned and authentication will not be tested.</param>
         /// <returns></returns>
         public async Task<LDAPPasswordUpdateResult> SetUserAccountPasswordForMsAD(DTO.LDAPDistinguishedNameCredential credential, string requestLabel = null, bool postUpdateTestAuthentication = true)
 		{
@@ -218,11 +218,11 @@ namespace Bitai.LDAPHelper
 				var entry = await verifyUserAccountAuthenticity(distinguishedName, requestLabel);
 
                 using (var ldapConnection = await GetLdapConnection(this.ConnectionInfo, this.DomainAccountCredential)) {
-                    //To disable an account name in MS AD, the userAccountControl attribute needs to be set with the appropriate flags. The flag for disabling an account name is ACCOUNTDISABLE (0x0002). However, when setting the userAccountControl attribute, it is important to preserve the existing flags that are set for the account, and only add the ACCOUNTDISABLE flag without removing any of the existing flags. This is because other flags may be set for the account name that are necessary for its proper functioning, and removing them could cause unintended consequences. Therefore, when disabling a username, you should retrieve the current value of the userAccountControl attribute, add the ACCOUNTDISABLE flag to it, and then update the attribute with the new value that includes both the existing flags and the ACCOUNTDISABLE flag.
+                    //To disable a MS AD user account, the userAccountControl attribute needs to be set with the appropriate flags. The flag for disabling an account is ACCOUNTDISABLE (0x0002). However, when setting the userAccountControl attribute, it is important to preserve the existing flags that are set for the account, and only add the ACCOUNTDISABLE flag without removing any of the existing flags. This is because other flags may be set for the account that are necessary for its proper functioning, and removing them could cause unintended consequences. Therefore, when disabling a username, you should retrieve the current value of the userAccountControl attribute, add the ACCOUNTDISABLE flag to it, and then update the attribute with the new value that includes both the existing flags and the ACCOUNTDISABLE flag.
                     UserAccountControlFlagsForMsAD userAccountControlFlags = UserAccountControlFlagsForMsAD.NORMAL_ACCOUNT | UserAccountControlFlagsForMsAD.ACCOUNTDISABLE;
                     //var userAccountControlAttribute = new LdapAttribute(DTO.EntryAttribute.userAccountControl.ToString(), ((int)userAccountControlFlags).ToString());
 
-                    //Create modification request to disable the account name by setting the userAccountControl attribute with the appropriate flags
+                    //Create modification request to disable the account by setting the userAccountControl attribute with the appropriate flags
                     var modification = ldapConnection.CreateModification(LdapModificationType.Replace, EntryAttribute.userAccountControl.ToString(),
                         ((int)userAccountControlFlags).ToString());
                     //var userAccountControlModification = new LdapModification(LdapModification.Replace, userAccountControlAttribute);

--- a/src/Bitai.LDAPHelper/Authenticator.cs
+++ b/src/Bitai.LDAPHelper/Authenticator.cs
@@ -178,7 +178,7 @@ namespace Bitai.LDAPHelper
                 if (authenticated.Value)
                     result.SetSuccessfulOperation($"The account with DN: {credential.DistinguishedName} has been successfully authenticated.");
                 else
-                    result.SetSuccessfulOperation("Authentication failed: incorrect account name or password.");
+                    result.SetSuccessfulOperation("Authentication failed: incorrect username or password.");
 
                 return result;
             }

--- a/src/Bitai.LDAPHelper/Authenticator.cs
+++ b/src/Bitai.LDAPHelper/Authenticator.cs
@@ -1,4 +1,4 @@
-﻿using Bitai.LDAPHelper.LdapAdapters;
+using Bitai.LDAPHelper.LdapAdapters;
 using Bitai.LDAPHelper.DTO;
 using Bitai.LDAPHelper.QueryFilters;
 using System;
@@ -42,7 +42,7 @@ namespace Bitai.LDAPHelper
                 else {
                     if (searchResult.Entries.Count() == 0) {
                         authenticationResult = new LDAPDomainAccountAuthenticationResult(credential.SecureClone(), false, requestLabel);
-                        authenticationResult.SetSuccessfulOperation($"The domain user account {credential.DomainName}\\{credential.AccountName} could not be found.");
+                        authenticationResult.SetSuccessfulOperation($"The domain username {credential.DomainName}\\{credential.AccountName} could not be found.");
 
                         return authenticationResult;
                     }
@@ -64,7 +64,7 @@ namespace Bitai.LDAPHelper
 
                 authenticationResult = new DTO.LDAPDomainAccountAuthenticationResult(credential.SecureClone(), authenticated.Value, requestLabel);
                 if (authenticated.Value)
-                    authenticationResult.SetSuccessfulOperation($"The domain user account {credential.DomainName}\\{credential.AccountName} has been successfully authenticated.");
+                    authenticationResult.SetSuccessfulOperation($"The domain username {credential.DomainName}\\{credential.AccountName} has been successfully authenticated.");
                 else
                     authenticationResult.SetSuccessfulOperation("The password is wrong");
 
@@ -93,9 +93,9 @@ namespace Bitai.LDAPHelper
                 var result = new DTO.LDAPDomainAccountAuthenticationResult(credential.SecureClone(), authenticated.Value, requestLabel);
 
                 if (authenticated.Value)
-                    result.SetSuccessfulOperation($"The domain user account {credential.DomainAccountName} has been successfully authenticated.");
+                    result.SetSuccessfulOperation($"The domain username {credential.DomainAccountName} has been successfully authenticated.");
                 else
-                    result.SetSuccessfulOperation("Wrong user account and/or password.");
+                    result.SetSuccessfulOperation("Wrong username and/or password.");
 
                 return result;
             }
@@ -130,7 +130,7 @@ namespace Bitai.LDAPHelper
                 else {
                     if (searchResult.Entries.Count() == 0) {
                         authenticationResult = new LDAPDistinguishedNameAuthenticationResult(credential.SecureClone(), false, requestLabel);
-                        authenticationResult.SetSuccessfulOperation($"The account {credential.DistinguishedName} could not be found.");
+                        authenticationResult.SetSuccessfulOperation($"Unable to locate the account's DN: {credential.DistinguishedName}");
 
                         return authenticationResult;
                     }
@@ -152,9 +152,9 @@ namespace Bitai.LDAPHelper
 
                 authenticationResult = new DTO.LDAPDistinguishedNameAuthenticationResult(credential.SecureClone(), authenticated.Value, requestLabel);
                 if (authenticated.Value)
-                    authenticationResult.SetSuccessfulOperation($"The account {credential.DistinguishedName} has been successfully authenticated.");
+                    authenticationResult.SetSuccessfulOperation($"The account with DN: {credential.DistinguishedName} has been successfully authenticated.");
                 else
-                    authenticationResult.SetSuccessfulOperation("The password is wrong");
+                    authenticationResult.SetSuccessfulOperation("Authentication failed: incorrect password.");
 
                 return authenticationResult;
             }
@@ -176,9 +176,9 @@ namespace Bitai.LDAPHelper
                 var result = new DTO.LDAPDistinguishedNameAuthenticationResult(credential.SecureClone(), authenticated.Value, requestLabel);
 
                 if (authenticated.Value)
-                    result.SetSuccessfulOperation($"The account {credential.DistinguishedName} has been successfully authenticated.");
+                    result.SetSuccessfulOperation($"The account with DN: {credential.DistinguishedName} has been successfully authenticated.");
                 else
-                    result.SetSuccessfulOperation("Wrong account and/or password.");
+                    result.SetSuccessfulOperation("Authentication failed: incorrect account name or password.");
 
                 return result;
             }

--- a/src/Bitai.LDAPHelper/Bitai.LDAPHelper.csproj
+++ b/src/Bitai.LDAPHelper/Bitai.LDAPHelper.csproj
@@ -1,16 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Authors>Viko Bastidas (BITAI)</Authors>
     <Company>BITAI</Company>
     <Product>LDAP Services Wrappers</Product>
     <Description>Library to wrap Novell.Directory.Ldap.NETStandard functionality to make LDAP common queries to search accounts and objects in a Directory Service.</Description>
     <Copyright>© 2026 BITAI. All rights reserved.</Copyright>
-    <Version>8.6.0</Version>
-    <AssemblyVersion>8.6.0.0</AssemblyVersion>
+    <Version>10.0.0</Version>
+    <AssemblyVersion>10.0.0</AssemblyVersion>
     <PackageIcon>hierarchy_32.png</PackageIcon>
-    <FileVersion>8.6.0.0</FileVersion>
+    <FileVersion>10.0.0</FileVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>Bitai.LDAPHelper</PackageId>
     <AssemblyName>Bitai.LDAPHelper</AssemblyName>
@@ -20,7 +20,7 @@
     <PackageTags>ldap;authentication;authorization;directory;helper;oauth;openid;ad;security;identity</PackageTags>
     <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
     <RootNamespace>Bitai.LDAPHelper</RootNamespace>
-    <PackageReleaseNotes>.NET 8 ready</PackageReleaseNotes>
+    <PackageReleaseNotes>.NET 10 ready</PackageReleaseNotes>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 

--- a/tests/Bitai.LDAPHelper.Tests.Mocks/Bitai.LDAPHelper.Tests.Mocks.csproj
+++ b/tests/Bitai.LDAPHelper.Tests.Mocks/Bitai.LDAPHelper.Tests.Mocks.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-	 <Version>8.6.0</Version>
-    <AssemblyVersion>8.6.0.0</AssemblyVersion>
-	 <FileVersion>8.6.0.0</FileVersion> 
+	 <Version>10.0.0</Version>
+    <AssemblyVersion>10.0.0</AssemblyVersion>
+	 <FileVersion>10.0.0</FileVersion> 
 	 <Authors>Viko Bastidas (BITAI)</Authors>
 	 <Copyright>© 2026 BITAI. All rights reserved.</Copyright>
 	 <RepositoryUrl>https://github.com/bitai-cs/LDAPHelper.git</RepositoryUrl>

--- a/tests/Bitai.LDAPHelper.Tests/AccountManagerAdapterTests.cs
+++ b/tests/Bitai.LDAPHelper.Tests/AccountManagerAdapterTests.cs
@@ -35,7 +35,7 @@ namespace Bitai.LDAPHelper.Tests
 
             // Assert
             Assert.True(result.IsSuccessfulOperation);
-            Assert.Contains("account nameX created at", result.OperationMessage.ToLower());
+            Assert.Contains("ms ad user account created at", result.OperationMessage.ToLower());
         }
 
         [Fact]

--- a/tests/Bitai.LDAPHelper.Tests/AccountManagerAdapterTests.cs
+++ b/tests/Bitai.LDAPHelper.Tests/AccountManagerAdapterTests.cs
@@ -1,4 +1,4 @@
-﻿using Bitai.LDAPHelper.DTO;
+using Bitai.LDAPHelper.DTO;
 using Bitai.LDAPHelper.Tests.Mocks.LdapAdapters;
 
 namespace Bitai.LDAPHelper.Tests
@@ -35,7 +35,7 @@ namespace Bitai.LDAPHelper.Tests
 
             // Assert
             Assert.True(result.IsSuccessfulOperation);
-            Assert.Contains("user account created at", result.OperationMessage.ToLower());
+            Assert.Contains("account nameX created at", result.OperationMessage.ToLower());
         }
 
         [Fact]

--- a/tests/Bitai.LDAPHelper.Tests/Bitai.LDAPHelper.Tests.csproj
+++ b/tests/Bitai.LDAPHelper.Tests/Bitai.LDAPHelper.Tests.csproj
@@ -1,22 +1,31 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
-    <AssemblyVersion>8.6.0.0</AssemblyVersion>
-    <FileVersion>8.6.0.0</FileVersion>
+    <AssemblyVersion>10.0.0</AssemblyVersion>
+    <FileVersion>10.0.0</FileVersion>
+    <Version>10.0.0</Version>
+    <UserSecretsId>5981b6a0-6b9e-439d-8324-a0ef8bfd0f11</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.8" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="Novell.Directory.Ldap.NETStandard" Version="4.0.0" />
-    <PackageReference Include="xunit" Version="2.5.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
.NET 10 and Component upgrades.

Additional some library messages fixes.

## Summary by Sourcery

.NET 10 upgrade and project housekeeping across solution, build, and messaging.

Enhancements:
- Standardize terminology from "user account" to "username" across LDAP operations and error messages for clearer semantics.
- Rename the main solution file to Bitai.Ldap.Helper.sln and update project metadata and repository configuration accordingly.
- Add an .editorconfig file to enforce consistent code style across the repository.

CI:
- Introduce a GitHub Actions CI workflow that restores, builds, and tests the solution using .NET 10 with dependency caching.

Documentation:
- Update README to remove the hard-coded .NET 8.0 reference, describe authentication using domain username terminology, and require .NET 10 SDK or higher.

Tests:
- Adjust unit tests to align with updated operation messages and terminology around account creation and authentication results.

Chores:
- Normalize BOM/encoding in several source and test files and perform minor wording refinements in user-facing messages.