### PR TITLE
Added or Updated XML docs.

### DIFF
--- a/demo/Bitai.LDAPHelper.Demo/Bitai.LDAPHelper.Demo.csproj
+++ b/demo/Bitai.LDAPHelper.Demo/Bitai.LDAPHelper.Demo.csproj
@@ -10,9 +10,9 @@
 		<Copyright>© 2026 BITAI. All rights reserved.</Copyright>
 		<PackageId>Bitai.Bitai.LDAPHelper.Demo</PackageId>
 		<PackageIcon>hierarchy_32.png</PackageIcon>
-		<Version>10.0.1</Version>
-		<AssemblyVersion>10.0.1</AssemblyVersion>
-		<FileVersion>10.0.1</FileVersion>
+		<Version>10.0.2</Version>
+		<AssemblyVersion>10.0.2</AssemblyVersion>
+		<FileVersion>10.0.2</FileVersion>
 		<PackageReleaseNotes>.NET 10 ready</PackageReleaseNotes>
 		<PackageTags>ldap-ad-identity-auth-openid-oauth-security</PackageTags>
 	</PropertyGroup>

--- a/demo/Bitai.LDAPHelper.Demo/DemoContext.cs
+++ b/demo/Bitai.LDAPHelper.Demo/DemoContext.cs
@@ -3,11 +3,29 @@ using Bitai.LDAPHelper.DTO;
 
 namespace Bitai.LDAPHelper.Demo;
 
+/// <summary>
+/// Holds runtime context and resolved settings for demo execution.
+/// </summary>
 public class DemoContext
 {
+    /// <summary>
+    /// Gets or sets which LDAP implementation to use.
+    /// </summary>
     public ImplementationType Implementation { get; set; }
+
+    /// <summary>
+    /// Gets or sets the connection-factory implementation used by demos.
+    /// </summary>
     public ILdapConnectionFactoryAdapter ConnectionFactory { get; set; }
+
+    /// <summary>
+    /// Gets or sets loaded demo configuration.
+    /// </summary>
     public DemoSetup Configuration { get; set; }
+
+    /// <summary>
+    /// Gets or sets the request label used by demo operations.
+    /// </summary>
     public string RequestLabel { get; set; } = "My Demo";
     
     // Connection settings
@@ -19,6 +37,10 @@ public class DemoContext
     public string SelectedDomainAccountPassword { get; set; }
     public string SelectedBaseDN { get; set; }
 
+    /// <summary>
+    /// Builds a <see cref="ConnectionInfo"/> instance from selected demo settings.
+    /// </summary>
+    /// <returns>Connection settings.</returns>
     public ConnectionInfo GetConnectionInfo()
     {
         return new ConnectionInfo(
@@ -28,6 +50,10 @@ public class DemoContext
             SelectedConnectionTimeout);
     }
 
+    /// <summary>
+    /// Builds a domain-account credential from selected demo settings.
+    /// </summary>
+    /// <returns>Domain-account credential.</returns>
     public LDAPDomainAccountCredential GetDomainAccountCredential()
     {
         var parts = SelectedDomainAccountName.Split(new char[] { '\\' });
@@ -37,6 +63,10 @@ public class DemoContext
             SelectedDomainAccountPassword);
     }
 
+    /// <summary>
+    /// Builds search limits from selected demo settings.
+    /// </summary>
+    /// <returns>Search-limit settings.</returns>
     public SearchLimits GetSearchLimits()
     {
         return new SearchLimits(SelectedBaseDN)
@@ -46,6 +76,10 @@ public class DemoContext
         };
     }
 
+    /// <summary>
+    /// Builds a full client configuration from selected demo settings.
+    /// </summary>
+    /// <returns>Client configuration for helper classes.</returns>
     public ClientConfiguration GetClientConfiguration()
     {
         return new ClientConfiguration(

--- a/demo/Bitai.LDAPHelper.Demo/DemoSetup.cs
+++ b/demo/Bitai.LDAPHelper.Demo/DemoSetup.cs
@@ -1,16 +1,36 @@
-﻿namespace Bitai.LDAPHelper.Demo;
+namespace Bitai.LDAPHelper.Demo;
 
+/// <summary>
+/// Selects the LDAP implementation used by demo scenarios.
+/// </summary>
 public enum ImplementationType {
 	Novell,
 	Mock
 }
 
+/// <summary>
+/// Represents configuration values used by demo scenarios.
+/// </summary>
 public class DemoSetup
 {
+	/// <summary>
+	/// Gets or sets available LDAP server endpoints for selection.
+	/// </summary>
 	public Ldapserver[] LdapServers { get; set; }
+
+	/// <summary>
+	/// Gets or sets available Base DN values for selection.
+	/// </summary>
 	public Basedn[] BaseDNs { get; set; }
+
+	/// <summary>
+	/// Gets or sets default LDAP connection timeout in seconds.
+	/// </summary>
 	public short ConnectionTimeout { get; set; }
 
+	/// <summary>
+	/// Gets or sets the domain account used as operator account during demo execution.
+	/// </summary>
 	public string DomainUserAccountForRunTests { get; set; }
 
 	public bool Demo_AccountManager_CreateUserAccount_RunTest { get; set; }
@@ -57,12 +77,24 @@ public class DemoSetup
 	public string Demo_GroupMembershipValidator_CheckGroupmembership_Check_GroupName { get; set; }
 }
 
+/// <summary>
+/// Represents an LDAP server option in demo configuration.
+/// </summary>
 public class Ldapserver
 {
+	/// <summary>
+	/// Gets or sets the LDAP server address.
+	/// </summary>
 	public string Address { get; set; }
 }
 
+/// <summary>
+/// Represents a Base DN option in demo configuration.
+/// </summary>
 public class Basedn
 {
+	/// <summary>
+	/// Gets or sets the base distinguished name.
+	/// </summary>
 	public string DN { get; set; }
 }

--- a/demo/Bitai.LDAPHelper.Demo/DemoSummary.cs
+++ b/demo/Bitai.LDAPHelper.Demo/DemoSummary.cs
@@ -4,11 +4,20 @@ using Serilog;
 
 namespace Bitai.LDAPHelper.Demo;
 
+/// <summary>
+/// Collects and prints summary information for executed demo scenarios.
+/// </summary>
 public class DemoSummary
 {
     private readonly Dictionary<string, bool> _demoResults = new Dictionary<string, bool>();
     private readonly List<string> _errors = new List<string>();
 
+    /// <summary>
+    /// Records the result of one demo scenario.
+    /// </summary>
+    /// <param name="demoName">Scenario name.</param>
+    /// <param name="success">Whether the scenario succeeded.</param>
+    /// <param name="error">Optional error associated with failure.</param>
     public void RecordDemoResult(string demoName, bool success, Exception error = null)
     {
         _demoResults[demoName] = success;
@@ -18,6 +27,9 @@ public class DemoSummary
         }
     }
 
+    /// <summary>
+    /// Prints an aggregated summary for all recorded demo results.
+    /// </summary>
     public void PrintSummary()
     {
         Console.WriteLine();

--- a/src/Bitai.LDAPHelper.DTO/Bitai.LDAPHelper.DTO.csproj
+++ b/src/Bitai.LDAPHelper.DTO/Bitai.LDAPHelper.DTO.csproj
@@ -2,9 +2,9 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <AssemblyVersion>10.0.0</AssemblyVersion>
-    <FileVersion>10.0.0</FileVersion>
-    <Version>10.0.0</Version>
+    <AssemblyVersion>10.0.1</AssemblyVersion>
+    <FileVersion>10.0.1</FileVersion>
+    <Version>10.0.1</Version>
     <AssemblyName>Bitai.LDAPHelper.DTO</AssemblyName>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Viko Bastidas (BITAI)</Authors>

--- a/src/Bitai.LDAPHelper.DTO/Enums.cs
+++ b/src/Bitai.LDAPHelper.DTO/Enums.cs
@@ -1,9 +1,12 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text;
 
 namespace Bitai.LDAPHelper.DTO
 {
+	/// <summary>
+	/// LDAP entry attributes that can be loaded or filtered.
+	/// </summary>
 	public enum EntryAttribute
 	{
 		/// <summary>
@@ -41,6 +44,9 @@ namespace Bitai.LDAPHelper.DTO
 		userAccountControl
 	}
 
+	/// <summary>
+	/// Predefined attribute sets used by search operations.
+	/// </summary>
 	public enum RequiredEntryAttributes
 	{
 		Minimun,

--- a/src/Bitai.LDAPHelper.DTO/ISecureCloningCredential.cs
+++ b/src/Bitai.LDAPHelper.DTO/ISecureCloningCredential.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -6,8 +6,16 @@ using System.Threading.Tasks;
 
 namespace Bitai.LDAPHelper.DTO
 {
+	/// <summary>
+	/// Defines secure cloning behavior used to remove or mask sensitive credential values.
+	/// </summary>
+	/// <typeparam name="T">Credential type returned by the secure clone operation.</typeparam>
 	internal interface ISecureCloningCredential<T>
 	{
+		/// <summary>
+		/// Creates a secure clone suitable for logging or transport without exposing secrets.
+		/// </summary>
+		/// <returns>A cloned credential with sensitive data removed or masked.</returns>
 		T SecureClone();
 	}
 }

--- a/src/Bitai.LDAPHelper.DTO/LDAPCreateMsADUserAccountResult.cs
+++ b/src/Bitai.LDAPHelper.DTO/LDAPCreateMsADUserAccountResult.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -6,8 +6,14 @@ using System.Threading.Tasks;
 
 namespace Bitai.LDAPHelper.DTO
 {
+	/// <summary>
+	/// Represents the result of an MS Active Directory user-account creation operation.
+	/// </summary>
 	public class LDAPCreateMsADUserAccountResult : LDAPOperationResult
 	{
+		/// <summary>
+		/// Gets or sets the created user account payload.
+		/// </summary>
 		public LDAPMsADUserAccount UserAccount { get; set; }
 
 
@@ -21,6 +27,13 @@ namespace Bitai.LDAPHelper.DTO
 			//Do not remove this constructor, it is required to deserialize data.
 		}
 
+		/// <summary>
+		/// Initializes a result for user-account creation.
+		/// </summary>
+		/// <param name="newUserAccount">Created user account data.</param>
+		/// <param name="requestLabel">Optional request label.</param>
+		/// <param name="operationMessage">Operation message.</param>
+		/// <param name="isSuccessfulOperation">Whether the operation is marked successful.</param>
 		public LDAPCreateMsADUserAccountResult(LDAPMsADUserAccount newUserAccount, string requestLabel = null, string operationMessage = "Operation completed", bool isSuccessfulOperation = true) : base(requestLabel, isSuccessfulOperation)
 		{
 			if (newUserAccount == null)
@@ -30,6 +43,12 @@ namespace Bitai.LDAPHelper.DTO
 			OperationMessage = operationMessage;
 		}
 
+		/// <summary>
+		/// Initializes an unsuccessful creation result from an exception.
+		/// </summary>
+		/// <param name="operationMessage">Operation message.</param>
+		/// <param name="exception">Underlying error.</param>
+		/// <param name="requestLabel">Optional request label.</param>
 		public LDAPCreateMsADUserAccountResult(string operationMessage, Exception exception, string requestLabel = null) : base(operationMessage, exception, requestLabel)
 		{
 		}

--- a/src/Bitai.LDAPHelper.DTO/LDAPDisableUserAccountOperationResult.cs
+++ b/src/Bitai.LDAPHelper.DTO/LDAPDisableUserAccountOperationResult.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -6,6 +6,9 @@ using System.Threading.Tasks;
 
 namespace Bitai.LDAPHelper.DTO
 {
+	/// <summary>
+	/// Represents the result of a user-account disable operation.
+	/// </summary>
 	public class LDAPDisableUserAccountOperationResult : LDAPOperationResult
 	{
 		/// <summary>
@@ -16,10 +19,21 @@ namespace Bitai.LDAPHelper.DTO
 			//Do not remove this constructor, it is required to deserialize data.
 		}
 
+		/// <summary>
+		/// Initializes a result for a disable operation.
+		/// </summary>
+		/// <param name="requestLabel">Optional request label.</param>
+		/// <param name="isSuccessfulOperation">Whether the operation is marked successful.</param>
 		public LDAPDisableUserAccountOperationResult(string requestLabel = null, bool isSuccessfulOperation = true) : base(requestLabel, isSuccessfulOperation)
 		{
 		}
 
+		/// <summary>
+		/// Initializes an unsuccessful disable-operation result from an exception.
+		/// </summary>
+		/// <param name="operationMessage">Operation message.</param>
+		/// <param name="exception">Underlying error.</param>
+		/// <param name="requestLabel">Optional request label.</param>
 		public LDAPDisableUserAccountOperationResult(string operationMessage, Exception exception, string requestLabel = null) : base(operationMessage, exception, requestLabel)
 		{
 		}

--- a/src/Bitai.LDAPHelper.DTO/LDAPDistinguishedNameAuthenticationResult.cs
+++ b/src/Bitai.LDAPHelper.DTO/LDAPDistinguishedNameAuthenticationResult.cs
@@ -1,4 +1,4 @@
-﻿using System.Net;
+using System.Net;
 using System;
 
 namespace Bitai.LDAPHelper.DTO;
@@ -9,6 +9,9 @@ namespace Bitai.LDAPHelper.DTO;
 /// </summary>
 public class LDAPDistinguishedNameAuthenticationResult: LDAPOperationResult
 {
+	/// <summary>
+	/// Gets or sets the credential associated with this authentication attempt.
+	/// </summary>
 	public LDAPDistinguishedNameCredential Credential { get; set; }
 
 	/// <summary>
@@ -28,12 +31,26 @@ public class LDAPDistinguishedNameAuthenticationResult: LDAPOperationResult
 		//Do not remove this constructor, it is required to deserialize data.
 	}
 
+	/// <summary>
+	/// Initializes an authentication result.
+	/// </summary>
+	/// <param name="credential">Credential associated with the authentication attempt.</param>
+	/// <param name="isAuthenticated">Authentication status.</param>
+	/// <param name="requestLabel">Optional request label.</param>
+	/// <param name="isSuccessfulOperation">Whether the operation is marked successful.</param>
 	public LDAPDistinguishedNameAuthenticationResult(LDAPDistinguishedNameCredential credential, bool isAuthenticated = true, string requestLabel = null, bool isSuccessfulOperation = true) : base(requestLabel, isSuccessfulOperation)
 	{
 		Credential = credential;
 		IsAuthenticated = isAuthenticated;
 	}
 
+	/// <summary>
+	/// Initializes an unsuccessful authentication result from an exception.
+	/// </summary>
+	/// <param name="credential">Credential associated with the authentication attempt.</param>
+	/// <param name="operationMessage">Operation message.</param>
+	/// <param name="exception">Underlying error.</param>
+	/// <param name="requestLabel">Optional request label.</param>
 	public LDAPDistinguishedNameAuthenticationResult(LDAPDistinguishedNameCredential credential, string operationMessage, Exception exception, string requestLabel = null) : base(operationMessage, exception, requestLabel)
 	{
 		Credential = credential;

--- a/src/Bitai.LDAPHelper.DTO/LDAPDistinguishedNameCredential.cs
+++ b/src/Bitai.LDAPHelper.DTO/LDAPDistinguishedNameCredential.cs
@@ -6,10 +6,19 @@ using System.Threading.Tasks;
 
 namespace Bitai.LDAPHelper.DTO
 {
+	/// <summary>
+	/// Represents credentials based on a distinguished name and password.
+	/// </summary>
 	public class LDAPDistinguishedNameCredential : ISecureCloningCredential<LDAPDistinguishedNameCredential>
 	{
+		/// <summary>
+		/// Gets or sets the account distinguished name.
+		/// </summary>
 		public string DistinguishedName { get; set; }
 
+		/// <summary>
+		/// Gets or sets the account password.
+		/// </summary>
 		public string Password { get; set; }
 
 
@@ -41,6 +50,10 @@ namespace Bitai.LDAPHelper.DTO
 
 
 
+		/// <summary>
+		/// Creates a clone with password removed.
+		/// </summary>
+		/// <returns>A cloned credential with sensitive information sanitized.</returns>
 		public LDAPDistinguishedNameCredential SecureClone()
 		{
 			var clone = new LDAPDistinguishedNameCredential

--- a/src/Bitai.LDAPHelper.DTO/LDAPDomainAccountAuthenticationResult.cs
+++ b/src/Bitai.LDAPHelper.DTO/LDAPDomainAccountAuthenticationResult.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace Bitai.LDAPHelper.DTO;
 
@@ -8,6 +8,9 @@ namespace Bitai.LDAPHelper.DTO;
 /// </summary>
 public class LDAPDomainAccountAuthenticationResult: LDAPOperationResult
 {
+	/// <summary>
+	/// Gets or sets the credential associated with this authentication attempt.
+	/// </summary>
 	public LDAPDomainAccountCredential Credential { get; set; }
 
 	/// <summary>
@@ -27,12 +30,26 @@ public class LDAPDomainAccountAuthenticationResult: LDAPOperationResult
 		//Do not remove this constructor, it is required to deserialize data.
 	}
 
+	/// <summary>
+	/// Initializes an authentication result.
+	/// </summary>
+	/// <param name="credential">Credential associated with the authentication attempt.</param>
+	/// <param name="isAuthenticated">Authentication status.</param>
+	/// <param name="requestLabel">Optional request label.</param>
+	/// <param name="isSuccessfulOperation">Whether the operation is marked successful.</param>
 	public LDAPDomainAccountAuthenticationResult(LDAPDomainAccountCredential credential, bool isAuthenticated = true, string requestLabel = null, bool isSuccessfulOperation = true) :base(requestLabel, isSuccessfulOperation)
 	{
 		Credential = credential;
 		IsAuthenticated = isAuthenticated;
 	}
 
+	/// <summary>
+	/// Initializes an unsuccessful authentication result from an exception.
+	/// </summary>
+	/// <param name="credential">Credential associated with the authentication attempt.</param>
+	/// <param name="operationMessage">Operation message.</param>
+	/// <param name="exception">Underlying error.</param>
+	/// <param name="requestLabel">Optional request label.</param>
 	public LDAPDomainAccountAuthenticationResult(LDAPDomainAccountCredential credential, string operationMessage, Exception exception, string requestLabel = null) : base(operationMessage, exception, requestLabel)
 	{
 		Credential = credential;

--- a/src/Bitai.LDAPHelper.DTO/LDAPDomainAccountCredential.cs
+++ b/src/Bitai.LDAPHelper.DTO/LDAPDomainAccountCredential.cs
@@ -7,12 +7,30 @@ using System.Threading.Tasks;
 
 namespace Bitai.LDAPHelper.DTO
 {
+	/// <summary>
+	/// Represents domain-account credentials in <c>Domain\\Account</c> format.
+	/// </summary>
 	public class LDAPDomainAccountCredential : ISecureCloningCredential<LDAPDomainAccountCredential>
 	{
+		/// <summary>
+		/// Gets or sets the domain name.
+		/// </summary>
 		public string DomainName { get; set; }
+
+		/// <summary>
+		/// Gets or sets the account (user) name.
+		/// </summary>
 		public string AccountName { get; set; }
+
+		/// <summary>
+		/// Gets the composite domain-account name in <c>Domain\\Account</c> format.
+		/// </summary>
 		[IgnoreDataMember]
 		public string DomainAccountName { get => $"{DomainName}\\{AccountName}"; }
+
+		/// <summary>
+		/// Gets or sets the account password.
+		/// </summary>
 		public string DomainAccountPassword { get; set; }
 
 
@@ -48,6 +66,10 @@ namespace Bitai.LDAPHelper.DTO
 
 
 
+		/// <summary>
+		/// Creates a clone with password removed.
+		/// </summary>
+		/// <returns>A cloned credential with sensitive information sanitized.</returns>
 		public LDAPDomainAccountCredential SecureClone()
 		{
 			return new LDAPDomainAccountCredential {

--- a/src/Bitai.LDAPHelper.DTO/LDAPEntry.cs
+++ b/src/Bitai.LDAPHelper.DTO/LDAPEntry.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text;
 
@@ -20,6 +20,9 @@ namespace Bitai.LDAPHelper.DTO
         }
         #endregion
 
+        /// <summary>
+        /// Gets or sets an optional caller-defined label used to correlate requests and results.
+        /// </summary>
         public string RequestLabel { get; set; }
 
         /// <summary>
@@ -37,14 +40,29 @@ namespace Bitai.LDAPHelper.DTO
         /// </summary>        
         public string company { get; set; }
 
+        /// <summary>
+        /// Country full name.
+        /// </summary>
         public string co { get; set; }
 
+        /// <summary>
+        /// Description.
+        /// </summary>
         public string description { get; set; }
 
+        /// <summary>
+        /// Department name.
+        /// </summary>
         public string department { get; set; }
 
+        /// <summary>
+        /// Display name.
+        /// </summary>
         public string displayName { get; set; }
 
+        /// <summary>
+        /// Distinguished name.
+        /// </summary>
         public string distinguishedName { get; set; }
 
         /// <summary>
@@ -52,50 +70,120 @@ namespace Bitai.LDAPHelper.DTO
         /// </summary>
         public string givenName { get; set; }
 
+        /// <summary>
+        /// Locality/city.
+        /// </summary>
         public string l { get; set; }
 
+        /// <summary>
+        /// Last logon date/time.
+        /// </summary>
         public DateTime? lastLogon { get; set; }
 
+        /// <summary>
+        /// Email address.
+        /// </summary>
         public string mail { get; set; }
 
+        /// <summary>
+        /// Manager distinguished name.
+        /// </summary>
         public string manager { get; set; }
 
+        /// <summary>
+        /// Members of this entry (for group entries).
+        /// </summary>
         public string[] member { get; set; }
 
+        /// <summary>
+        /// Parent groups distinguished names.
+        /// </summary>
         public string[] memberOf { get; set; }
 
+        /// <summary>
+        /// Parent entries expanded from <see cref="memberOf"/>.
+        /// </summary>
         public IEnumerable<LDAPEntry> memberOfEntries { get; set; }
 
+        /// <summary>
+        /// LDAP <c>name</c> attribute.
+        /// </summary>
         public string name { get; set; }
 
+        /// <summary>
+        /// Object category.
+        /// </summary>
         public string objectCategory { get; set; }
 
+        /// <summary>
+        /// Object classes.
+        /// </summary>
         public string[] objectClass { get; set; }
 
+        /// <summary>
+        /// sAMAccountName.
+        /// </summary>
         public string samAccountName { get; set; }
 
+        /// <summary>
+        /// sAMAccountType symbolic value.
+        /// </summary>
         public string samAccountType { get; set; }
 
+        /// <summary>
+        /// Surname.
+        /// </summary>
         public string sn { get; set; }
 
+        /// <summary>
+        /// Telephone number.
+        /// </summary>
         public string telephoneNumber { get; set; }
 
+        /// <summary>
+        /// Job title.
+        /// </summary>
         public string title { get; set; }
 
+        /// <summary>
+        /// User principal name.
+        /// </summary>
         public string userPrincipalName { get; set; }
 
+        /// <summary>
+        /// Entry creation date/time.
+        /// </summary>
         public DateTime? whenCreated { get; set; }
 
+        /// <summary>
+        /// Object GUID string.
+        /// </summary>
         public string objectGuid { get; set; }
 
+        /// <summary>
+        /// Object GUID bytes.
+        /// </summary>
         public byte[] objectGuidBytes { get; set; }
 
+        /// <summary>
+        /// Object SID string.
+        /// </summary>
         public string objectSid { get; set; }
 
+        /// <summary>
+        /// Object SID bytes.
+        /// </summary>
         public byte[] objectSidBytes { get; set; }
 
+        /// <summary>
+        /// Raw userAccountControl attribute value.
+        /// </summary>
         public string? userAccountControl { get; set; }
 
+        /// <summary>
+        /// Recursively gets all parent entries from the <see cref="memberOfEntries"/> hierarchy.
+        /// </summary>
+        /// <returns>A flattened sequence of parent entries.</returns>
         public IEnumerable<LDAPEntry> GetMemberOfEntriesRecursively()
         {
             var _list = new List<LDAPEntry>();
@@ -114,6 +202,12 @@ namespace Bitai.LDAPHelper.DTO
 
 
         #region IComparable Members
+        /// <summary>
+        /// Compares this entry with another by distinguished name.
+        /// </summary>
+        /// <param name="obj">Entry to compare against.</param>
+        /// <returns>Comparison result.</returns>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="obj"/> is not an <see cref="LDAPEntry"/>.</exception>
         public int CompareTo(object obj)
         {
             if (obj is LDAPEntry)

--- a/src/Bitai.LDAPHelper.DTO/LDAPMsADUserAccount.cs
+++ b/src/Bitai.LDAPHelper.DTO/LDAPMsADUserAccount.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -57,18 +57,68 @@ namespace Bitai.LDAPHelper.DTO
 
 
 
+		/// <summary>
+		/// Gets or sets the distinguished name of the container where the user account should be created.
+		/// </summary>
 		public string DistinguishedNameOfContainer { get => distinguishedNameOfContainer; set => distinguishedNameOfContainer = value; }
+
+		/// <summary>
+		/// Gets or sets the user's given name.
+		/// </summary>
 		public string GivenName { get => givenName; set => givenName = value; }
+
+		/// <summary>
+		/// Gets or sets the user's surname.
+		/// </summary>
 		public string Sn { get => sn; set => sn = value; }
+
+		/// <summary>
+		/// Gets or sets the user common name (CN).
+		/// </summary>
 		public string Cn { get => cn; set => cn = value; }
+
+		/// <summary>
+		/// Gets or sets the LDAP <c>name</c> attribute.
+		/// </summary>
 		public string Name { get => name; set => name = value; }
+
+		/// <summary>
+		/// Gets or sets the display name.
+		/// </summary>
 		public string DisplayName { get => displayName; set => displayName = value; }
+
+		/// <summary>
+		/// Gets or sets the account description.
+		/// </summary>
 		public string Description { get => description; set => description = value; }
+
+		/// <summary>
+		/// Gets or sets the full distinguished name of the user account.
+		/// </summary>
 		public string DistinguishedName { get => distinguishedName; set => distinguishedName = value; }
+
+		/// <summary>
+		/// Gets or sets parent groups (distinguished names) this account belongs to.
+		/// </summary>
 		public string[] MemberOf { get => memberOf; set => memberOf = value; }
+
+		/// <summary>
+		/// Gets or sets LDAP object classes for this account.
+		/// </summary>
 		public string[] ObjectClass { get => objectClass; set => objectClass = value; }
+
+		/// <summary>
+		/// Gets or sets the sAMAccountName value.
+		/// </summary>
 		public string SAMAccountName { get => samAccountName; set => samAccountName = value; }
+
+		/// <summary>
+		/// Gets or sets the user principal name (UPN).
+		/// </summary>
 		public string UserPrincipalName { get => userPrincipalName; set => userPrincipalName = value; }
+		/// <summary>
+		/// Gets or sets user-account-control flags as a comma-separated list of <see cref="UserAccountControlFlagsForMsAD"/> names.
+		/// </summary>
 		public string UserAccountControl
 		{
 			get => userAccountControl;
@@ -100,14 +150,37 @@ namespace Bitai.LDAPHelper.DTO
 				}
 			}
 		}
+		/// <summary>
+		/// Gets or sets the department.
+		/// </summary>
 		public string Department { get => department; set => department = value; }
+
+		/// <summary>
+		/// Gets or sets the phone number.
+		/// </summary>
 		public string TelephoneNumber { get => telephoneNumber; set => telephoneNumber = value; }
+
+		/// <summary>
+		/// Gets or sets the email address.
+		/// </summary>
 		public string Mail { get => mail; set => mail = value; }
+
+		/// <summary>
+		/// Gets or sets the account password.
+		/// </summary>
 		public string Password { get => password; set => password = value; }
+
+		/// <summary>
+		/// Gets parsed account-control flags derived from <see cref="UserAccountControl"/>.
+		/// </summary>
 		public UserAccountControlFlagsForMsAD? UserAccountControlFlags { get => userAccountControlFlags; }
 
 
 
+		/// <summary>
+		/// Creates a secure clone with password masked.
+		/// </summary>
+		/// <returns>A cloned account suitable for logging/transport.</returns>
 		public LDAPMsADUserAccount SecureClone()
 		{
 			return new LDAPMsADUserAccount

--- a/src/Bitai.LDAPHelper.DTO/LDAPPasswordUpdateResult.cs
+++ b/src/Bitai.LDAPHelper.DTO/LDAPPasswordUpdateResult.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.VisualBasic;
+using Microsoft.VisualBasic;
 using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
@@ -6,20 +6,35 @@ using System.Text;
 
 namespace Bitai.LDAPHelper.DTO
 {
+	/// <summary>
+	/// Represents the result of an LDAP password update operation.
+	/// </summary>
 	public class LDAPPasswordUpdateResult : LDAPOperationResult
 	{
 		/// <summary>
-		/// Defaulr constructor.
+		/// Default constructor.
 		/// </summary>
 		public LDAPPasswordUpdateResult() {
 			//Do not remove this constructor, it is required to deserialize data.
 		}
 
+		/// <summary>
+		/// Initializes a password-update result.
+		/// </summary>
+		/// <param name="requesttag">Optional request label.</param>
+		/// <param name="operationMessage">Operation message.</param>
+		/// <param name="isSuccessfulOperation">Whether the operation is marked successful.</param>
 		public LDAPPasswordUpdateResult(string requesttag = null, string operationMessage = "Operation completed.", bool isSuccessfulOperation = true) : base(requesttag, isSuccessfulOperation)
 		{
 			OperationMessage = operationMessage;
 		}
 
+		/// <summary>
+		/// Initializes an unsuccessful password-update result from an exception.
+		/// </summary>
+		/// <param name="operationMessage">Operation message.</param>
+		/// <param name="ex">Underlying error.</param>
+		/// <param name="requestLabel">Optional request label.</param>
 		public LDAPPasswordUpdateResult(string operationMessage, Exception ex, string requestLabel = null) : base(operationMessage, ex, requestLabel)
 		{
 		}

--- a/src/Bitai.LDAPHelper.DTO/LDAPRemoveMsADUserAccountResult.cs
+++ b/src/Bitai.LDAPHelper.DTO/LDAPRemoveMsADUserAccountResult.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -6,6 +6,9 @@ using System.Threading.Tasks;
 
 namespace Bitai.LDAPHelper.DTO
 {
+	/// <summary>
+	/// Represents the result of an MS Active Directory user-account removal operation.
+	/// </summary>
 	public class LDAPRemoveMsADUserAccountResult : LDAPOperationResult
 	{
 		/// <summary>
@@ -16,11 +19,23 @@ namespace Bitai.LDAPHelper.DTO
 			//Do not remove this constructor, it is required to deserialize data.
 		}
 
+		/// <summary>
+		/// Initializes a remove-account operation result.
+		/// </summary>
+		/// <param name="requestLabel">Optional request label.</param>
+		/// <param name="operationMessage">Operation message.</param>
+		/// <param name="isSuccessfulOperation">Whether the operation is marked successful.</param>
 		public LDAPRemoveMsADUserAccountResult(string requestLabel = null, string operationMessage = "Operation completed", bool isSuccessfulOperation = true) : base(requestLabel, isSuccessfulOperation)
 		{
 			OperationMessage = operationMessage;
 		}
 
+		/// <summary>
+		/// Initializes an unsuccessful remove-account result from an exception.
+		/// </summary>
+		/// <param name="operationMessage">Operation message.</param>
+		/// <param name="exception">Underlying error.</param>
+		/// <param name="requestLabel">Optional request label.</param>
 		public LDAPRemoveMsADUserAccountResult(string operationMessage, Exception exception, string requestLabel = null) : base(operationMessage, exception, requestLabel)
 		{
 		}

--- a/src/Bitai.LDAPHelper.DTO/LDAPSearchResult.cs
+++ b/src/Bitai.LDAPHelper.DTO/LDAPSearchResult.cs
@@ -1,10 +1,13 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
 using System.Text;
 
 namespace Bitai.LDAPHelper.DTO
 {
+	/// <summary>
+	/// Represents the result of an LDAP search operation.
+	/// </summary>
 	public class LDAPSearchResult : LDAPOperationResult
 	{
 		/// <summary>
@@ -16,13 +19,20 @@ namespace Bitai.LDAPHelper.DTO
 
 
 		/// <summary>
-		/// Defaulr constructor.
+		/// Default constructor.
 		/// </summary>
 		public LDAPSearchResult()
 		{
 			//Do not remove this constructor, it is required to deserialize data.
 		}
 
+		/// <summary>
+		/// Initializes a successful or unsuccessful search result with entries.
+		/// </summary>
+		/// <param name="requestLabel">Optional request label.</param>
+		/// <param name="entries">Entries returned by the search.</param>
+		/// <param name="operationMessage">Operation message.</param>
+		/// <param name="isSuccessfulOperation">Whether the operation is marked successful.</param>
 		public LDAPSearchResult(string requestLabel = null, IEnumerable<LDAPHelper.DTO.LDAPEntry> entries = null, string operationMessage = "Operation completed.", bool isSuccessfulOperation = true) : base(requestLabel, isSuccessfulOperation)
 		{
 			if (entries != null)
@@ -33,6 +43,12 @@ namespace Bitai.LDAPHelper.DTO
 			OperationMessage = operationMessage;
 		}
 
+		/// <summary>
+		/// Initializes an unsuccessful search result from an exception.
+		/// </summary>
+		/// <param name="operationMessage">Operation message.</param>
+		/// <param name="exception">Underlying error.</param>
+		/// <param name="requestLabel">Optional request label.</param>
 		public LDAPSearchResult(string operationMessage, Exception exception, string requestLabel = null) : base(operationMessage, exception, requestLabel)
 		{
 		}

--- a/src/Bitai.LDAPHelper.LdapAdapters/Enums.cs
+++ b/src/Bitai.LDAPHelper.LdapAdapters/Enums.cs
@@ -5,8 +5,19 @@ namespace Bitai.LDAPHelper.LdapAdapters;
 /// </summary>
 public enum LdapModificationType
 {
+    /// <summary>
+    /// Adds an attribute value.
+    /// </summary>
     Add = 0,
+
+    /// <summary>
+    /// Deletes an attribute value.
+    /// </summary>
     Delete = 1,
+
+    /// <summary>
+    /// Replaces an attribute value.
+    /// </summary>
     Replace = 2
 }
 
@@ -15,7 +26,18 @@ public enum LdapModificationType
 /// </summary>
 public enum LdapSearchScope
 {
+    /// <summary>
+    /// Search only the base object.
+    /// </summary>
     ScopeBase = 0,
+
+    /// <summary>
+    /// Search one level below the base object.
+    /// </summary>
     ScopeOne = 1,
+
+    /// <summary>
+    /// Search the entire subtree below the base object.
+    /// </summary>
     ScopeSub = 2
 }

--- a/src/Bitai.LDAPHelper.LdapAdapters/IConnectionInfo.cs
+++ b/src/Bitai.LDAPHelper.LdapAdapters/IConnectionInfo.cs
@@ -1,9 +1,27 @@
 namespace Bitai.LDAPHelper.LdapAdapters;
 
+/// <summary>
+/// Defines LDAP server connection settings required to open an LDAP connection.
+/// </summary>
 public interface IConnectionInfo
 {
+    /// <summary>
+    /// Gets the connection timeout in seconds.
+    /// </summary>
     short ConnectionTimeout { get; }
+
+    /// <summary>
+    /// Gets the LDAP server host name or IP address.
+    /// </summary>
     string Server { get; }
+
+    /// <summary>
+    /// Gets the LDAP server port.
+    /// </summary>
     int ServerPort { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether SSL must be used.
+    /// </summary>
     bool UseSSL { get; }
 }

--- a/src/Bitai.LDAPHelper.LdapAdapters/ILdapAttributeAdapter.cs
+++ b/src/Bitai.LDAPHelper.LdapAdapters/ILdapAttributeAdapter.cs
@@ -1,12 +1,27 @@
-﻿namespace Bitai.LDAPHelper.LdapAdapters; 
+namespace Bitai.LDAPHelper.LdapAdapters; 
 
 /// <summary>
-/// Target interface for LDAP attribute operations
+/// Defines read access to LDAP attribute values in multiple representations.
 /// </summary>
 public interface ILdapAttributeAdapter
 {
+    /// <summary>
+    /// Gets the first binary value of the attribute.
+    /// </summary>
     byte[] ByteValue { get; }
+
+    /// <summary>
+    /// Gets the first string value of the attribute.
+    /// </summary>
     string StringValue { get; }
+
+    /// <summary>
+    /// Gets all string values of the attribute.
+    /// </summary>
     string[] StringValueArray { get; }
-    public byte[][] ByteValueArray { get; }
+
+    /// <summary>
+    /// Gets all binary values of the attribute.
+    /// </summary>
+    byte[][] ByteValueArray { get; }
 }

--- a/src/Bitai.LDAPHelper.LdapAdapters/ILdapAttributeSetAdapter.cs
+++ b/src/Bitai.LDAPHelper.LdapAdapters/ILdapAttributeSetAdapter.cs
@@ -1,13 +1,42 @@
-﻿namespace Bitai.LDAPHelper.LdapAdapters;
+namespace Bitai.LDAPHelper.LdapAdapters;
 
 /// <summary>
-/// Target interface for LDAP AttributeSet operations
+/// Defines operations for building and reading LDAP attribute sets.
 /// </summary>
 public interface ILdapAttributeSetAdapter
 {
+    /// <summary>
+    /// Adds a single string value to an attribute.
+    /// </summary>
+    /// <param name="name">Attribute name.</param>
+    /// <param name="value">Attribute value.</param>
     void AddAttribute(string name, string value);
+
+    /// <summary>
+    /// Adds multiple string values to an attribute.
+    /// </summary>
+    /// <param name="name">Attribute name.</param>
+    /// <param name="values">Attribute values.</param>
     void AddAttribute(string name, string[] values);
+
+    /// <summary>
+    /// Adds a binary value to an attribute.
+    /// </summary>
+    /// <param name="name">Attribute name.</param>
+    /// <param name="value">Binary attribute value.</param>
     void AddAttribute(string name, byte[] value);
+
+    /// <summary>
+    /// Determines whether an attribute exists in the set.
+    /// </summary>
+    /// <param name="attributeName">Attribute name to look up.</param>
+    /// <returns><see langword="true"/> if found; otherwise <see langword="false"/>.</returns>
     bool ContainsKey(string attributeName);
+
+    /// <summary>
+    /// Gets an attribute by name.
+    /// </summary>
+    /// <param name="attributeName">Attribute name.</param>
+    /// <returns>The attribute adapter when found; otherwise <see langword="null"/>.</returns>
     ILdapAttributeAdapter GetAttribute(string attributeName);        
 }

--- a/src/Bitai.LDAPHelper.LdapAdapters/ILdapConnectionAdapter.cs
+++ b/src/Bitai.LDAPHelper.LdapAdapters/ILdapConnectionAdapter.cs
@@ -5,22 +5,97 @@ using System.Threading.Tasks;
 namespace Bitai.LDAPHelper.LdapAdapters;
 
 /// <summary>
-/// Target interface for LDAP connection operations
+/// Defines the operations required to manage and use an LDAP connection.
 /// </summary>
 public interface ILdapConnectionAdapter : IDisposable
 {
+    /// <summary>
+    /// Gets or sets the connection timeout in milliseconds.
+    /// </summary>
     int ConnectionTimeout { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether SSL is enabled.
+    /// </summary>
     bool SecureSocketLayer { get; set; }
+
+    /// <summary>
+    /// Gets a value indicating whether the connection is authenticated (bound).
+    /// </summary>
     bool IsBound { get; }
 
+    /// <summary>
+    /// Bypasses server certificate validation.
+    /// </summary>
+    /// <remarks>Use only in controlled environments.</remarks>
     void ServerCertificateValidationByPass(); 
+
+    /// <summary>
+    /// Connects to the LDAP server.
+    /// </summary>
+    /// <param name="host">Server host name or IP address.</param>
+    /// <param name="port">Server port.</param>
+    /// <returns>A task that completes when the connection is established.</returns>
     Task ConnectAsync(string host, int port);
+
+    /// <summary>
+    /// Authenticates the connection.
+    /// </summary>
+    /// <param name="userDN">User distinguished name or account identifier.</param>
+    /// <param name="password">Account password.</param>
+    /// <returns>A task that completes when bind finishes.</returns>
     Task BindAsync(string userDN, string password);
+
+    /// <summary>
+    /// Executes an LDAP search.
+    /// </summary>
+    /// <param name="searchLimits">Search boundaries and limits.</param>
+    /// <param name="searchFilter">LDAP filter expression.</param>
+    /// <param name="attributeNames">Attributes to return.</param>
+    /// <param name="typesOnly">Whether only attribute names should be returned.</param>
+    /// <returns>A queue adapter with server responses.</returns>
     Task<ILdapSearchQueueAdapter> SearchAsync(ISearchLimits searchLimits, string searchFilter, string[] attributeNames, bool typesOnly);
+
+    /// <summary>
+    /// Creates an empty attribute set for add/update operations.
+    /// </summary>
+    /// <returns>An attribute set adapter.</returns>
     ILdapAttributeSetAdapter CreateAttributeSet();
+
+    /// <summary>
+    /// Adds an entry to the directory.
+    /// </summary>
+    /// <param name="distinguishedName">Distinguished name for the new entry.</param>
+    /// <param name="attributes">Attribute set for the new entry.</param>
+    /// <returns>A task that completes when the entry is created.</returns>
     Task AddEntryAsync(string distinguishedName, ILdapAttributeSetAdapter attributes);
+
+    /// <summary>
+    /// Creates a modification descriptor.
+    /// </summary>
+    /// <param name="type">Modification type.</param>
+    /// <param name="attributeName">Attribute name to modify.</param>
+    /// <param name="value">New attribute value.</param>
+    /// <returns>A modification adapter.</returns>
     ILdapModificationAdapter CreateModification(LdapModificationType type, string attributeName, object value);
+
+    /// <summary>
+    /// Applies modifications to an existing entry.
+    /// </summary>
+    /// <param name="distinguishedName">Target entry distinguished name.</param>
+    /// <param name="modifications">Modifications to apply.</param>
+    /// <returns>A task that completes when the update finishes.</returns>
     Task ModifyEntryAsync(string distinguishedName, IEnumerable<ILdapModificationAdapter> modifications);
+
+    /// <summary>
+    /// Deletes an entry from the directory.
+    /// </summary>
+    /// <param name="distinguishedName">Target entry distinguished name.</param>
+    /// <returns>A task that completes when deletion finishes.</returns>
     Task DeleteEntryAsync(string distinguishedName);
+
+    /// <summary>
+    /// Disconnects the connection from the server.
+    /// </summary>
     void Disconnect();
 }

--- a/src/Bitai.LDAPHelper.LdapAdapters/ILdapConnectionFactoryAdapter.cs
+++ b/src/Bitai.LDAPHelper.LdapAdapters/ILdapConnectionFactoryAdapter.cs
@@ -1,10 +1,20 @@
 namespace Bitai.LDAPHelper.LdapAdapters;
 
 /// <summary>
-/// Factory interface for creating LDAP connections
+/// Defines a factory for creating initialized LDAP connections.
 /// </summary>
 public interface ILdapConnectionFactoryAdapter
 {
+    /// <summary>
+    /// Creates a new LDAP connection and optionally binds it with credentials.
+    /// </summary>
+    /// <param name="connectionInfo">Server connection settings.</param>
+    /// <param name="userAccount">Account identifier used for bind.</param>
+    /// <param name="password">Account password used for bind.</param>
+    /// <param name="bindRequired">
+    /// <see langword="true"/> to fail when bind cannot be completed; otherwise <see langword="false"/>.
+    /// </param>
+    /// <returns>A task with an initialized LDAP connection adapter.</returns>
     Task<ILdapConnectionAdapter> CreateConnectionAsync(
         IConnectionInfo connectionInfo,
         string userAccount,

--- a/src/Bitai.LDAPHelper.LdapAdapters/ILdapEntryAdapter.cs
+++ b/src/Bitai.LDAPHelper.LdapAdapters/ILdapEntryAdapter.cs
@@ -1,10 +1,18 @@
-﻿namespace Bitai.LDAPHelper.LdapAdapters;
+namespace Bitai.LDAPHelper.LdapAdapters;
 
 /// <summary>
-/// Target interface for LDAP entry operations
+/// Defines read access to an LDAP entry and its attribute set.
 /// </summary>
 public interface ILdapEntryAdapter
 {
+    /// <summary>
+    /// Gets the distinguished name of the entry.
+    /// </summary>
     string DistinguishedName { get; }
+
+    /// <summary>
+    /// Gets the attribute set associated with the entry.
+    /// </summary>
+    /// <returns>An attribute set adapter.</returns>
     ILdapAttributeSetAdapter GetAttributeSet();
 }

--- a/src/Bitai.LDAPHelper.LdapAdapters/ILdapMessageAdapter.cs
+++ b/src/Bitai.LDAPHelper.LdapAdapters/ILdapMessageAdapter.cs
@@ -1,11 +1,22 @@
-﻿namespace Bitai.LDAPHelper.LdapAdapters;
+namespace Bitai.LDAPHelper.LdapAdapters;
 
 /// <summary>
-/// Target interface for LDAP message operations
+/// Defines accessors for LDAP protocol messages returned by search operations.
 /// </summary>
 public interface ILdapMessageAdapter
 {
+    /// <summary>
+    /// Gets the LDAP entry when the message represents a search result; otherwise <see langword="null"/>.
+    /// </summary>
     ILdapEntryAdapter Entry { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether this message is a search-result message.
+    /// </summary>
     bool IsSearchResult { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether this message signals end-of-search.
+    /// </summary>
     bool IsSearchDone { get; }
 }

--- a/src/Bitai.LDAPHelper.LdapAdapters/ILdapModificationAdapter.cs
+++ b/src/Bitai.LDAPHelper.LdapAdapters/ILdapModificationAdapter.cs
@@ -1,10 +1,17 @@
-﻿namespace Bitai.LDAPHelper.LdapAdapters;
+namespace Bitai.LDAPHelper.LdapAdapters;
 
 /// <summary>
-/// Adapter for LDAP modification operations
+/// Defines access to a single LDAP modification operation.
 /// </summary>
 public interface ILdapModificationAdapter
 {
+    /// <summary>
+    /// Gets the modification operation type.
+    /// </summary>
     LdapModificationType ModificationType { get; }
+
+    /// <summary>
+    /// Gets the attribute associated with the modification.
+    /// </summary>
     ILdapAttributeAdapter Attribute { get; }
 }

--- a/src/Bitai.LDAPHelper.LdapAdapters/ILdapSearchConstraintsAdapter.cs
+++ b/src/Bitai.LDAPHelper.LdapAdapters/ILdapSearchConstraintsAdapter.cs
@@ -1,10 +1,17 @@
-﻿namespace Bitai.LDAPHelper.LdapAdapters;
+namespace Bitai.LDAPHelper.LdapAdapters;
 
 /// <summary>
-/// Target interface for LDAP search constraints
+/// Defines LDAP server-side search constraints.
 /// </summary>
 public interface ILdapSearchConstraintsAdapter
 {
+    /// <summary>
+    /// Gets or sets the server-side time limit in seconds.
+    /// </summary>
     int ServerTimeLimit { get; set; }
+
+    /// <summary>
+    /// Gets or sets the maximum number of entries returned by the server.
+    /// </summary>
     int MaxResults { get; set; }
 }

--- a/src/Bitai.LDAPHelper.LdapAdapters/ILdapSearchQueueAdapter.cs
+++ b/src/Bitai.LDAPHelper.LdapAdapters/ILdapSearchQueueAdapter.cs
@@ -1,9 +1,13 @@
-﻿namespace Bitai.LDAPHelper.LdapAdapters;
+namespace Bitai.LDAPHelper.LdapAdapters;
 
 /// <summary>
-/// Target interface for LDAP search queue operations
+/// Defines access to queued LDAP search responses.
 /// </summary>
 public interface ILdapSearchQueueAdapter
 {
+    /// <summary>
+    /// Gets the next response from the queue.
+    /// </summary>
+    /// <returns>The next message adapter; or <see langword="null"/> when no more responses are available.</returns>
     ILdapMessageAdapter GetResponse();
 }

--- a/src/Bitai.LDAPHelper.LdapAdapters/ISearchLimits.cs
+++ b/src/Bitai.LDAPHelper.LdapAdapters/ISearchLimits.cs
@@ -1,9 +1,27 @@
 namespace Bitai.LDAPHelper.LdapAdapters;
 
+/// <summary>
+/// Defines LDAP search boundaries and limits.
+/// </summary>
 public interface ISearchLimits
 {
+    /// <summary>
+    /// Gets or sets the base distinguished name from which the search starts.
+    /// </summary>
     string BaseDN { get; set; }
+
+    /// <summary>
+    /// Gets or sets the LDAP search scope.
+    /// </summary>
     LdapSearchScope LdapSearchScope { get; set; }
+
+    /// <summary>
+    /// Gets or sets the maximum number of entries to return.
+    /// </summary>
     int MaxSearchResults { get; set; }
+
+    /// <summary>
+    /// Gets or sets the maximum server processing time in seconds.
+    /// </summary>
     int MaxSearchTimeout { get; set; }
 }

--- a/src/Bitai.LDAPHelper/AccountManager.cs
+++ b/src/Bitai.LDAPHelper/AccountManager.cs
@@ -10,21 +10,37 @@ using Novell.Directory.Ldap;
 
 namespace Bitai.LDAPHelper
 {
+    /// <summary>
+    /// Provides account-management operations for LDAP/Active Directory entries.
+    /// </summary>
 	public class AccountManager : BaseHelper
 	{
         #region Constructors
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AccountManager"/> class.
+        /// </summary>
+        /// <param name="clientConfiguration">Client configuration containing connection, credential, and search settings.</param>
+        /// <param name="connectionFactory">LDAP connection factory abstraction.</param>
         public AccountManager(ClientConfiguration clientConfiguration, ILdapConnectionFactoryAdapter connectionFactory)
             : base(clientConfiguration, connectionFactory) {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AccountManager"/> class.
+        /// </summary>
+        /// <param name="connectionInfo">LDAP server connection settings.</param>
+        /// <param name="searchLimits">LDAP search limits.</param>
+        /// <param name="domainAccountCredential">Credential used for management operations.</param>
+        /// <param name="connectionFactory">LDAP connection factory abstraction.</param>
         public AccountManager(ConnectionInfo connectionInfo, SearchLimits searchLimits, DTO.LDAPDomainAccountCredential domainAccountCredential, ILdapConnectionFactoryAdapter connectionFactory)
             : base(connectionInfo, searchLimits, domainAccountCredential, connectionFactory) {
         }
         #endregion
 
-
-
-
+        /// <summary>
+        /// Initializes the account distinguished name when it is missing.
+        /// </summary>
+        /// <param name="userAccount">User-account model to normalize.</param>
         public void InitializeMissingMsADUserAccountDN(LDAPMsADUserAccount userAccount)
 		{
 			if (string.IsNullOrEmpty(userAccount.DistinguishedName))
@@ -36,7 +52,6 @@ namespace Bitai.LDAPHelper
         /// https://www.rlmueller.net/Name_Attributes.htm
         /// </summary>
         /// <param name="newUserAccount"><see cref="LDAPMsADUserAccount"/></param>
-        /// <param name="distinguishedNameOfContainer">DN of the container in which the username will be created.</param>
         /// <param name="requestLabel">Optional tag to mark the request and/or response.</param>
         /// <returns>A Task of <see cref="LDAPCreateMsADUserAccountResult"/></returns>
         public async Task<LDAPCreateMsADUserAccountResult> CreateUserAccountForMsAD(LDAPMsADUserAccount newUserAccount, string requestLabel = null)
@@ -173,10 +188,12 @@ namespace Bitai.LDAPHelper
         /// <summary>
         /// Set a password for a username in MS Active Directory service. This method will verify the authenticity of the username by its distinguished name before trying to set the password. If the username is not valid, the operation will not be attempted and an error will be returned.
         /// </summary>
-        /// <param name="credential"><see cref="LDAPDistinguishedNameCredential"/></param>
+        /// <param name="identifierAttribute">Identifier attribute used to resolve the user account (sAMAccountName or distinguishedName).</param>
+        /// <param name="identifierValue">Value of the identifier attribute.</param>
+        /// <param name="password">New account password.</param>
         /// <param name="requestLabel">Optional tag to mark the request and/or response.</param>
         /// <param name="postUpdateTestAuthentication">True if the MS AD user account will be tested to verify authentication with the new password. False if the password will simply be assigned and authentication will not be tested.</param>
-        /// <returns></returns>
+        /// <returns>A task with the password-update operation result.</returns>
         public async Task<LDAPPasswordUpdateResult> SetMsADUserAccountPassword(EntryAttribute identifierAttribute, string identifierValue, string password, string requestLabel = null, bool postUpdateTestAuthentication = true)
 		{
 			try
@@ -250,9 +267,10 @@ namespace Bitai.LDAPHelper
         }
 
         /// <summary>
-        /// Remove a username from MS Active Directory service. This method will verify the authenticity of the username by its distinguished name before trying to remove it. If the username is not valid, the operation will not be attempted and an error will be returned.
+        /// Disables a username in MS Active Directory. This method validates the target account first.
         /// </summary>
-        /// <param name="identifierValue">Distinguished name of the username</param>
+        /// <param name="identifierAttribute">Identifier attribute used to resolve the user account (sAMAccountName or distinguishedName).</param>
+        /// <param name="identifierValue">Value of the identifier attribute.</param>
         /// <param name="requestLabel">Optional tag to mark the request and/or response.</param>
         /// <returns><see cref="LDAPDisableUserAccountOperationResult"/></returns>
         public async Task<LDAPDisableUserAccountOperationResult> DisableMsADUserAccount(EntryAttribute identifierAttribute, string identifierValue, string requestLabel)
@@ -304,7 +322,8 @@ namespace Bitai.LDAPHelper
         /// <summary>
         /// Remove a username in MS Active Directory service. This operation will permanently delete the username entry from the directory, so it should be used with caution.
         /// </summary>
-        /// <param name="identifierValue">Distinguished name of the username</param>
+        /// <param name="identifierAttribute">Identifier attribute used to resolve the user account (sAMAccountName or distinguishedName).</param>
+        /// <param name="identifierValue">Value of the identifier attribute.</param>
         /// <param name="requestLabel">Optional tag to mark the request and/or response.</param>
         /// <returns><see cref="LDAPRemoveMsADUserAccountResult"/></returns>
         public async Task<LDAPRemoveMsADUserAccountResult> RemoveMsADUserAccount(EntryAttribute identifierAttribute, string identifierValue, string requestLabel = null)

--- a/src/Bitai.LDAPHelper/Authenticator.cs
+++ b/src/Bitai.LDAPHelper/Authenticator.cs
@@ -7,15 +7,33 @@ using System.Threading.Tasks;
 
 namespace Bitai.LDAPHelper
 {
+    /// <summary>
+    /// Provides LDAP authentication workflows for domain-account and distinguished-name credentials.
+    /// </summary>
     public class Authenticator : BaseHelper
     {
         #region Constructors
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Authenticator"/> class.
+        /// </summary>
+        /// <param name="connectionInfo">LDAP server connection settings.</param>
+        /// <param name="connectionFactory">LDAP connection factory abstraction.</param>
         public Authenticator(ConnectionInfo connectionInfo, ILdapConnectionFactoryAdapter connectionFactory) : base(connectionInfo, connectionFactory) {
         }
         #endregion
 
 
         #region Public methods
+        /// <summary>
+        /// Authenticates a domain account and validates that exactly one matching LDAP user exists.
+        /// </summary>
+        /// <param name="credential">Credential to authenticate.</param>
+        /// <param name="searchLimits">Search limits used to locate the account before authentication.</param>
+        /// <param name="credentialForSearching">Credential used to perform the validation search.</param>
+        /// <param name="requestLabel">Optional label used to correlate request/response operations.</param>
+        /// <returns>
+        /// A result object containing operation status, authentication status, and optional error details.
+        /// </returns>
         public async Task<LDAPDomainAccountAuthenticationResult> AuthenticateAsync(LDAPDomainAccountCredential credential, SearchLimits searchLimits, LDAPDomainAccountCredential credentialForSearching, string requestLabel = null) {
             LDAPDomainAccountAuthenticationResult authenticationResult;
 
@@ -78,10 +96,13 @@ namespace Bitai.LDAPHelper
         }
 
         /// <summary>
-        /// Authenticate <see cref="Credentials"/> on the LDAP Server
+        /// Authenticates a domain account directly against the LDAP server.
         /// </summary>
-        /// <param name="credential"><see cref="Credentials"/> to connect and authenticate on the LDAP Server.</param>
-        /// <returns>True or false, if authenticated or no.</returns>
+        /// <param name="credential">Credential to authenticate.</param>
+        /// <param name="requestLabel">Optional label used to correlate request/response operations.</param>
+        /// <returns>
+        /// A result object containing operation status, authentication status, and optional error details.
+        /// </returns>
         public async Task<LDAPDomainAccountAuthenticationResult> AuthenticateAsync(LDAPDomainAccountCredential credential, string requestLabel = null) {
             try {
                 bool? authenticated;
@@ -106,6 +127,16 @@ namespace Bitai.LDAPHelper
             }
         }
 
+        /// <summary>
+        /// Authenticates a distinguished-name account and validates that exactly one matching LDAP user exists.
+        /// </summary>
+        /// <param name="credential">Credential to authenticate.</param>
+        /// <param name="searchLimits">Search limits used to locate the account before authentication.</param>
+        /// <param name="credentialForSearching">Credential used to perform the validation search.</param>
+        /// <param name="requestLabel">Optional label used to correlate request/response operations.</param>
+        /// <returns>
+        /// A result object containing operation status, authentication status, and optional error details.
+        /// </returns>
         public async Task<LDAPDistinguishedNameAuthenticationResult> AuthenticateAsync(LDAPDistinguishedNameCredential credential, SearchLimits searchLimits, LDAPDomainAccountCredential credentialForSearching, string requestLabel = null) {
             LDAPDistinguishedNameAuthenticationResult authenticationResult;
 
@@ -165,6 +196,14 @@ namespace Bitai.LDAPHelper
             }
         }
 
+        /// <summary>
+        /// Authenticates a distinguished-name account directly against the LDAP server.
+        /// </summary>
+        /// <param name="credential">Credential to authenticate.</param>
+        /// <param name="requestLabel">Optional label used to correlate request/response operations.</param>
+        /// <returns>
+        /// A result object containing operation status, authentication status, and optional error details.
+        /// </returns>
         public async Task<LDAPDistinguishedNameAuthenticationResult> AuthenticateAsync(LDAPDistinguishedNameCredential credential, string requestLabel = null) {
             try {
                 bool? authenticated;

--- a/src/Bitai.LDAPHelper/BaseHelper.cs
+++ b/src/Bitai.LDAPHelper/BaseHelper.cs
@@ -7,17 +7,40 @@ using Bitai.LDAPHelper.LdapAdapters;
 
 namespace Bitai.LDAPHelper
 {
+	/// <summary>
+	/// Base class for LDAP helper services, providing shared connection and mapping utilities.
+	/// </summary>
 	public abstract partial class BaseHelper
 	{
 		#region Properties
+		/// <summary>
+		/// Gets or sets LDAP server connection settings.
+		/// </summary>
 		public ConnectionInfo ConnectionInfo { get; set; }
+
+		/// <summary>
+		/// Gets or sets the credential used for LDAP search/management operations.
+		/// </summary>
 		public DTO.LDAPDomainAccountCredential DomainAccountCredential { get; set; }
+
+		/// <summary>
+		/// Gets or sets default LDAP search limits.
+		/// </summary>
 		public SearchLimits SearchLimits { get; set; }
+
+		/// <summary>
+		/// Gets or sets the LDAP connection factory abstraction.
+		/// </summary>
         protected ILdapConnectionFactoryAdapter ConnectionFactory { get; set; }
         #endregion
 
 
         #region Protected constructors
+		/// <summary>
+		/// Initializes a new instance of the <see cref="BaseHelper"/> class.
+		/// </summary>
+		/// <param name="clientConfiguration">Client configuration containing connection, credential, and search settings.</param>
+		/// <param name="connectionFactory">LDAP connection factory abstraction.</param>
         protected BaseHelper(ClientConfiguration clientConfiguration, ILdapConnectionFactoryAdapter connectionFactory)
 		{
 			ConnectionInfo = clientConfiguration.ServerSettings;
@@ -26,6 +49,13 @@ namespace Bitai.LDAPHelper
 			ConnectionFactory = connectionFactory;
         }
 
+		/// <summary>
+		/// Initializes a new instance of the <see cref="BaseHelper"/> class.
+		/// </summary>
+		/// <param name="connectionInfo">LDAP server connection settings.</param>
+		/// <param name="searchLimits">LDAP search limits.</param>
+		/// <param name="domainAccountCredential">Credential used by LDAP operations.</param>
+		/// <param name="connectionFactory">LDAP connection factory abstraction.</param>
 		protected BaseHelper(ConnectionInfo connectionInfo, SearchLimits searchLimits, DTO.LDAPDomainAccountCredential domainAccountCredential, ILdapConnectionFactoryAdapter connectionFactory)
 		{
 			ConnectionInfo = connectionInfo;
@@ -36,9 +66,10 @@ namespace Bitai.LDAPHelper
         }
 
 		/// <summary>
-		/// Constructor used by <see cref="Authenticator"/>
+		/// Initializes a new instance of the <see cref="BaseHelper"/> class used by authentication-only services.
 		/// </summary>
-		/// <param name="connectionInfo"><see cref="LDAPHelper.ConnectionInfo"/></param>
+		/// <param name="connectionInfo">LDAP server connection settings.</param>
+		/// <param name="connectionFactory">LDAP connection factory abstraction.</param>
 		protected BaseHelper(ConnectionInfo connectionInfo, ILdapConnectionFactoryAdapter connectionFactory)
 		{
 			ConnectionInfo = connectionInfo;
@@ -48,6 +79,11 @@ namespace Bitai.LDAPHelper
 
 
 		#region Protected methods
+		/// <summary>
+		/// Converts a SAM account-type numeric code to a symbolic name.
+		/// </summary>
+		/// <param name="index">String representation of the SAM account type numeric value.</param>
+		/// <returns>A symbolic account type name when known; otherwise the original value.</returns>
 		protected string GetSAMAccountTypeName(string index)
 		{
 			switch (index)
@@ -78,12 +114,12 @@ namespace Bitai.LDAPHelper
 		}
 
 		/// <summary>
-		/// Get <see cref="LdapConnection"/>
+		/// Creates and optionally binds an LDAP connection using domain-account credentials.
 		/// </summary>
-		/// <param name="connectionInfo"><see cref="LDAPHelper.ConnectionInfo"/> to connect to the LDAP Server</param>
-		/// <param name="credential"><see cref="DomainAccountCredential"/>  to connect to the LDAP Server</param>
-		/// <param name="bindRequired">If <see cref="DomainAccountCredential"/> are required to be mandatorily authenticated on the LDAP Server</param>
-		/// <returns>Task of <see cref="LdapConnection"/></returns>
+		/// <param name="connectionInfo">LDAP server connection settings.</param>
+		/// <param name="credential">Domain-account credential used for bind.</param>
+		/// <param name="bindRequired">Whether bind/authentication is required.</param>
+		/// <returns>A task with an initialized LDAP connection adapter.</returns>
 		protected async Task<ILdapConnectionAdapter> GetLdapConnection(ConnectionInfo connectionInfo, DTO.LDAPDomainAccountCredential credential, bool bindRequired = true)
 		{
             //return getLdapConnection(connectionInfo, credential.DomainAccountName, credential.DomainAccountPassword, bindRequired);
@@ -95,6 +131,13 @@ namespace Bitai.LDAPHelper
                 bindRequired);
         }
 
+		/// <summary>
+		/// Creates and optionally binds an LDAP connection using distinguished-name credentials.
+		/// </summary>
+		/// <param name="connectionInfo">LDAP server connection settings.</param>
+		/// <param name="credential">Distinguished-name credential used for bind.</param>
+		/// <param name="bindRequired">Whether bind/authentication is required.</param>
+		/// <returns>A task with an initialized LDAP connection adapter.</returns>
 		protected async Task<ILdapConnectionAdapter> GetLdapConnection(ConnectionInfo connectionInfo, DTO.LDAPDistinguishedNameCredential credential, bool bindRequired = true)
 		{
             //return getLdapConnection(connectionInfo, credential.DistinguishedName, credential.Password, bindRequired);
@@ -106,6 +149,11 @@ namespace Bitai.LDAPHelper
                 bindRequired);
         }
 
+		/// <summary>
+		/// Converts a binary SID value into its canonical string representation.
+		/// </summary>
+		/// <param name="sidBytes">Binary SID value.</param>
+		/// <returns>Canonical SID string (for example, S-1-5-21-...).</returns>
 		protected string ConvertByteToStringSid(byte[] sidBytes)
 		{
 			short sSubAuthorityCount = 0;
@@ -153,6 +201,11 @@ namespace Bitai.LDAPHelper
 			return strSid.ToString();
 		}
 
+		/// <summary>
+		/// Resolves the LDAP attribute names to request based on a predefined attribute-set preset.
+		/// </summary>
+		/// <param name="requiredEntryAttributes">Preset indicating which attributes should be loaded.</param>
+		/// <returns>A sequence of attribute names to request in LDAP search operations.</returns>
 		protected IEnumerable<string> GetRequiredAttributeNames(DTO.RequiredEntryAttributes requiredEntryAttributes)
 		{
 			switch (requiredEntryAttributes)

--- a/src/Bitai.LDAPHelper/Bitai.LDAPHelper.csproj
+++ b/src/Bitai.LDAPHelper/Bitai.LDAPHelper.csproj
@@ -7,9 +7,9 @@
     <Product>LDAP Services Wrappers</Product>
     <Description>Library to wrap Novell.Directory.Ldap.NETStandard functionality to make LDAP common queries to search accounts and objects in a Directory Service.</Description>
     <Copyright>© 2026 BITAI. All rights reserved.</Copyright>
-    <Version>10.1.2</Version>
-    <AssemblyVersion>10.1.2</AssemblyVersion>
-    <FileVersion>10.1.2</FileVersion>
+    <Version>10.1.3</Version>
+    <AssemblyVersion>10.1.3</AssemblyVersion>
+    <FileVersion>10.1.3</FileVersion>
     <PackageIcon>hierarchy_32.png</PackageIcon>    
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>Bitai.LDAPHelper</PackageId>
@@ -22,6 +22,7 @@
     <RootNamespace>Bitai.LDAPHelper</RootNamespace>
     <PackageReleaseNotes>.NET 10 ready</PackageReleaseNotes>
     <PackageReadmeFile>README.md</PackageReadmeFile>
+    <GenerateDocumentationFile>True</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Bitai.LDAPHelper/ClientConfiguration.cs
+++ b/src/Bitai.LDAPHelper/ClientConfiguration.cs
@@ -1,19 +1,22 @@
-﻿namespace Bitai.LDAPHelper
+namespace Bitai.LDAPHelper
 {
+	/// <summary>
+	/// Encapsulates LDAP client runtime configuration.
+	/// </summary>
 	public class ClientConfiguration
 	{
 		/// <summary>
-		/// <see cref="ConnectionInfo"/>
+		/// Gets or sets LDAP server connection settings.
 		/// </summary>
 		public ConnectionInfo ServerSettings { get; set; }
 
 		/// <summary>
-		/// <see cref="Credentials"/>
+		/// Gets or sets the service account used for LDAP operations.
 		/// </summary>
 		public DTO.LDAPDomainAccountCredential DomainAccountCredential { get; set; }
 
         /// <summary>
-        /// <see cref="LDAPHelper.SearchLimits"/>
+		/// Gets or sets LDAP search limits.
         /// </summary>
         public SearchLimits SearchLimits { get; set; }
 
@@ -21,7 +24,7 @@
         /// Constructor
         /// </summary>
         /// <param name="serverSettings"><see cref="ConnectionInfo"/></param>
-        /// <param name="domainAccountCredentials"><see cref="DomainAccountCredential"/></param>
+		/// <param name="domainAccountCredentials">Domain account credential used for bind/search operations.</param>
         /// <param name="searchLimits"><see cref="LDAPHelper.SearchLimits"/></param>
         public ClientConfiguration(ConnectionInfo serverSettings, DTO.LDAPDomainAccountCredential domainAccountCredentials, SearchLimits searchLimits)
 		{

--- a/src/Bitai.LDAPHelper/ConnectionInfo.cs
+++ b/src/Bitai.LDAPHelper/ConnectionInfo.cs
@@ -2,8 +2,18 @@ using Bitai.LDAPHelper.LdapAdapters;
 
 namespace Bitai.LDAPHelper
 {
+    /// <summary>
+    /// Represents LDAP server connection settings.
+    /// </summary>
     public class ConnectionInfo : IConnectionInfo
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ConnectionInfo"/> class.
+        /// </summary>
+        /// <param name="server">LDAP server host name or IP address.</param>
+        /// <param name="port">LDAP server port.</param>
+        /// <param name="useSSL">Whether SSL is enabled.</param>
+        /// <param name="connectionTimeout">Connection timeout in seconds.</param>
         public ConnectionInfo(string server, int port, bool useSSL, short connectionTimeout)
         {
             Server = server;
@@ -12,10 +22,19 @@ namespace Bitai.LDAPHelper
             ConnectionTimeout = connectionTimeout;
         }
 
+        /// <summary>
+        /// Gets the LDAP server host name or IP address.
+        /// </summary>
         public string Server { get; }
 
+        /// <summary>
+        /// Gets the LDAP server port.
+        /// </summary>
         public int ServerPort { get; }
 
+        /// <summary>
+        /// Gets a value indicating whether SSL is enabled.
+        /// </summary>
         public bool UseSSL { get; }
 
         /// <summary>

--- a/src/Bitai.LDAPHelper/DataValidationException.cs
+++ b/src/Bitai.LDAPHelper/DataValidationException.cs
@@ -2,17 +2,32 @@ using System;
 
 namespace Bitai.LDAPHelper
 {
+    /// <summary>
+    /// Represents errors caused by invalid or inconsistent business data supplied to LDAP operations.
+    /// </summary>
     [Serializable]
     public class DataValidationException : Exception
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DataValidationException"/> class.
+        /// </summary>
         public DataValidationException()
         {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DataValidationException"/> class with a message.
+        /// </summary>
+        /// <param name="message">Validation error message.</param>
         public DataValidationException(string message) : base(message)
         {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DataValidationException"/> class with a message and inner exception.
+        /// </summary>
+        /// <param name="message">Validation error message.</param>
+        /// <param name="innerException">Underlying cause of this exception.</param>
         public DataValidationException(string message, Exception innerException) : base(message, innerException)
         {
         }

--- a/src/Bitai.LDAPHelper/EntryNotFoundException.cs
+++ b/src/Bitai.LDAPHelper/EntryNotFoundException.cs
@@ -1,13 +1,25 @@
-﻿using System;
+using System;
 
 namespace Bitai.LDAPHelper
 {
+	/// <summary>
+	/// Represents errors when a requested LDAP entry cannot be found.
+	/// </summary>
 	public class EntryNotFoundException : Exception
 	{
+		/// <summary>
+		/// Initializes a new instance of the <see cref="EntryNotFoundException"/> class with a message.
+		/// </summary>
+		/// <param name="message">Error message.</param>
 		public EntryNotFoundException(string message) : base(message)
 		{
 		}
 
+		/// <summary>
+		/// Initializes a new instance of the <see cref="EntryNotFoundException"/> class with a message and inner exception.
+		/// </summary>
+		/// <param name="message">Error message.</param>
+		/// <param name="innerException">Underlying cause of this exception.</param>
 		public EntryNotFoundException(string message, Exception innerException) : base(message, innerException)
 		{
 		}

--- a/src/Bitai.LDAPHelper/Enums.cs
+++ b/src/Bitai.LDAPHelper/Enums.cs
@@ -5,9 +5,24 @@ namespace Bitai.LDAPHelper
     /// </summary>
 	public enum LdapServerDefaultPorts : int
 	{
+		/// <summary>
+		/// Default LDAP port.
+		/// </summary>
 		DefaultPort = 389,
+
+		/// <summary>
+		/// Default LDAP-over-SSL port.
+		/// </summary>
 		DefaultSslPort = 636,
+
+		/// <summary>
+		/// Default Global Catalog port.
+		/// </summary>
 		DefaultGlobalCatalogPort = 3268,
+
+		/// <summary>
+		/// Default Global Catalog SSL port.
+		/// </summary>
 		DefaultGlobalCatalogSslPort = 3269
 	}    
 }

--- a/src/Bitai.LDAPHelper/Extensions/IEnumerableLDAPEntryExtensions.cs
+++ b/src/Bitai.LDAPHelper/Extensions/IEnumerableLDAPEntryExtensions.cs
@@ -1,10 +1,18 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Bitai.LDAPHelper.Extensions
 {
+    /// <summary>
+    /// Provides extension methods for LDAP entry collections.
+    /// </summary>
     public static class IEnumerableLDAPEntryExtensions
     {
+        /// <summary>
+        /// Flattens all <c>memberOfEntries</c> hierarchies recursively for every entry in the sequence.
+        /// </summary>
+        /// <param name="entries">Source LDAP entries.</param>
+        /// <returns>A distinct flattened sequence of parent/group entries.</returns>
         public static IEnumerable<DTO.LDAPEntry> SelectAllMemberOfEntriesRecursively(this IEnumerable<DTO.LDAPEntry> entries)
         {
             var partialList = new List<DTO.LDAPEntry>();

--- a/src/Bitai.LDAPHelper/Extensions/StringExtensions.cs
+++ b/src/Bitai.LDAPHelper/Extensions/StringExtensions.cs
@@ -1,22 +1,45 @@
-﻿namespace Bitai.LDAPHelper.Extensions
+namespace Bitai.LDAPHelper.Extensions
 {
+    /// <summary>
+    /// Provides LDAP-safe string escaping helpers.
+    /// </summary>
     public static class StringExtensions
     {
+        /// <summary>
+        /// Escapes parenthesis characters for LDAP filter usage.
+        /// </summary>
+        /// <param name="input">Input text.</param>
+        /// <returns>Escaped text.</returns>
         public static string ReplaceParenthesisCharsToScapedChars(this string input)
         {
             return input.Replace("(", "\\28").Replace(")", "\\29");
         }
 
+        /// <summary>
+        /// Escapes asterisk characters for LDAP filter usage.
+        /// </summary>
+        /// <param name="input">Input text.</param>
+        /// <returns>Escaped text.</returns>
         public static string ReplaceAsteriskCharsToScapedChars(this string input)
         {
             return input.Replace("*", "\\2A");
         }
 
+        /// <summary>
+        /// Escapes backslash characters for LDAP filter usage.
+        /// </summary>
+        /// <param name="input">Input text.</param>
+        /// <returns>Escaped text.</returns>
         public static string ReplaceBackslashCharsToScapedChars(this string input)
         {
             return input.Replace("\\", "\\5C");
         }
 
+        /// <summary>
+        /// Escapes special LDAP filter characters (backslash, asterisk, parenthesis).
+        /// </summary>
+        /// <param name="input">Input text.</param>
+        /// <returns>Escaped text.</returns>
         public static string ReplaceSpecialCharsToScapedChars(this string input)
         {
             return ReplaceParenthesisCharsToScapedChars(ReplaceAsteriskCharsToScapedChars(ReplaceBackslashCharsToScapedChars(input)));

--- a/src/Bitai.LDAPHelper/GroupMembershipValidator.cs
+++ b/src/Bitai.LDAPHelper/GroupMembershipValidator.cs
@@ -1,17 +1,32 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Bitai.LDAPHelper.LdapAdapters;
 
 namespace Bitai.LDAPHelper
 {
+    /// <summary>
+    /// Validates group membership relationships for directory users.
+    /// </summary>
     public class GroupMembershipValidator : BaseHelper
     {
         #region Constructors
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GroupMembershipValidator"/> class.
+        /// </summary>
+        /// <param name="clientConfiguration">Client configuration containing connection, credential, and search settings.</param>
+        /// <param name="connectionFactory">LDAP connection factory abstraction.</param>
         public GroupMembershipValidator(ClientConfiguration clientConfiguration, ILdapConnectionFactoryAdapter connectionFactory)
             : base(clientConfiguration, connectionFactory) {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GroupMembershipValidator"/> class.
+        /// </summary>
+        /// <param name="connectionInfo">LDAP server connection settings.</param>
+        /// <param name="searchLimits">LDAP search limits.</param>
+        /// <param name="domainAccountCredential">Credential used to execute LDAP searches.</param>
+        /// <param name="connectionFactory">LDAP connection factory abstraction.</param>
         public GroupMembershipValidator(
             ConnectionInfo connectionInfo,
             SearchLimits searchLimits,

--- a/src/Bitai.LDAPHelper/LdapAdapters/Novell/NovellLdapAttributeAdapter.cs
+++ b/src/Bitai.LDAPHelper/LdapAdapters/Novell/NovellLdapAttributeAdapter.cs
@@ -1,23 +1,31 @@
-﻿using Novell.Directory.Ldap;
+using Novell.Directory.Ldap;
 
 namespace Bitai.LDAPHelper.LdapAdapters.Novell;
 
 /// <summary>
-/// Adapter for Novell.Directory.Ldap.LdapAttribute
+/// Adapter for <see cref="LdapAttribute"/>.
 /// </summary>
 public class NovellLdapAttributeAdapter : ILdapAttributeAdapter
 {
     private readonly LdapAttribute _attribute;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NovellLdapAttributeAdapter"/> class.
+    /// </summary>
+    /// <param name="attribute">Wrapped Novell LDAP attribute.</param>
     public NovellLdapAttributeAdapter(LdapAttribute attribute) {
         _attribute = attribute;
     }
 
+    /// <inheritdoc/>
     public byte[] ByteValue => _attribute.ByteValue;
 
+    /// <inheritdoc/>
     public string StringValue => _attribute.StringValue;
 
+    /// <inheritdoc/>
     public string[] StringValueArray => _attribute.StringValueArray;
 
+    /// <inheritdoc/>
     public byte[][] ByteValueArray => _attribute.ByteValueArray;
 }

--- a/src/Bitai.LDAPHelper/LdapAdapters/Novell/NovellLdapConnectionFactoryAdapter.cs
+++ b/src/Bitai.LDAPHelper/LdapAdapters/Novell/NovellLdapConnectionFactoryAdapter.cs
@@ -5,10 +5,11 @@ using Novell.Directory.Ldap;
 namespace Bitai.LDAPHelper.LdapAdapters.Novell;
 
 /// <summary>
-/// Factory for creating Novell LDAP connection adapters
+/// Factory for creating Novell LDAP connection adapters.
 /// </summary>
 public class NovellLdapConnectionFactoryAdapter : ILdapConnectionFactoryAdapter
 {
+    /// <inheritdoc/>
     public async Task<ILdapConnectionAdapter> CreateConnectionAsync(
         IConnectionInfo connectionInfo,
         string userAccount,

--- a/src/Bitai.LDAPHelper/LdapAdapters/Novell/NovellLdapEntryAdapter.cs
+++ b/src/Bitai.LDAPHelper/LdapAdapters/Novell/NovellLdapEntryAdapter.cs
@@ -1,20 +1,26 @@
-﻿using Novell.Directory.Ldap;
+using Novell.Directory.Ldap;
 
 namespace Bitai.LDAPHelper.LdapAdapters.Novell;
 
 /// <summary>
-/// Adapter for Novell.Directory.Ldap.LdapEntry
+/// Adapter for <see cref="LdapEntry"/>.
 /// </summary>
 public class NovellLdapEntryAdapter : ILdapEntryAdapter
 {
     private readonly LdapEntry _entry;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NovellLdapEntryAdapter"/> class.
+    /// </summary>
+    /// <param name="entry">Wrapped Novell LDAP entry.</param>
     public NovellLdapEntryAdapter(LdapEntry entry) {
         _entry = entry;
     }
 
+    /// <inheritdoc/>
     public string DistinguishedName => _entry.Dn;
 
+    /// <inheritdoc/>
     public ILdapAttributeSetAdapter GetAttributeSet() {
         return new NovellLdapAttributeSetAdapter(_entry.GetAttributeSet());
     }

--- a/src/Bitai.LDAPHelper/LdapAdapters/Novell/NovellLdapMessageAdapter.cs
+++ b/src/Bitai.LDAPHelper/LdapAdapters/Novell/NovellLdapMessageAdapter.cs
@@ -1,18 +1,23 @@
-﻿using Novell.Directory.Ldap;
+using Novell.Directory.Ldap;
 
 namespace Bitai.LDAPHelper.LdapAdapters.Novell;
 
 /// <summary>
-/// Adapter for Novell.Directory.Ldap.LdapMessage
+/// Adapter for <see cref="LdapMessage"/>.
 /// </summary>
 public class NovellLdapMessageAdapter : ILdapMessageAdapter
 {
     private readonly LdapMessage _message;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NovellLdapMessageAdapter"/> class.
+    /// </summary>
+    /// <param name="message">Wrapped LDAP message.</param>
     public NovellLdapMessageAdapter(LdapMessage message) {
         _message = message;
     }
 
+    /// <inheritdoc/>
     public ILdapEntryAdapter Entry {
         get {
             if (_message is LdapSearchResult searchResult && searchResult.Entry != null)
@@ -21,8 +26,10 @@ public class NovellLdapMessageAdapter : ILdapMessageAdapter
         }
     }
 
+    /// <inheritdoc/>
     public bool IsSearchResult => _message is LdapSearchResult;
 
+    /// <inheritdoc/>
     public bool IsSearchDone {
         get {
             throw new System.Exception();

--- a/src/Bitai.LDAPHelper/LdapAdapters/Novell/NovellLdapSearchQueueAdapter.cs
+++ b/src/Bitai.LDAPHelper/LdapAdapters/Novell/NovellLdapSearchQueueAdapter.cs
@@ -3,16 +3,21 @@ using Novell.Directory.Ldap;
 namespace Bitai.LDAPHelper.LdapAdapters.Novell;
 
 /// <summary>
-/// Adapter for Novell.Directory.Ldap.LdapSearchQueue
+/// Adapter for <see cref="LdapSearchQueue"/>.
 /// </summary>
 public class NovellLdapSearchQueueAdapter : ILdapSearchQueueAdapter
 {
     private readonly LdapSearchQueue _searchQueue;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NovellLdapSearchQueueAdapter"/> class.
+    /// </summary>
+    /// <param name="searchQueue">Wrapped search queue.</param>
     public NovellLdapSearchQueueAdapter(LdapSearchQueue searchQueue) {
         _searchQueue = searchQueue;
     }
 
+    /// <inheritdoc/>
     public ILdapMessageAdapter GetResponse() {
         LdapMessage message = _searchQueue.GetResponse();
         return message != null ? new NovellLdapMessageAdapter(message) : null;

--- a/src/Bitai.LDAPHelper/LdapOperationException.cs
+++ b/src/Bitai.LDAPHelper/LdapOperationException.cs
@@ -2,12 +2,24 @@ using System;
 
 namespace Bitai.LDAPHelper;
 
+/// <summary>
+/// Represents generic LDAP operation failures in helper workflows.
+/// </summary>
 public class LdapOperationException : Exception
 {
+	/// <summary>
+	/// Initializes a new instance of the <see cref="LdapOperationException"/> class with a message.
+	/// </summary>
+	/// <param name="message">Error message.</param>
 	public LdapOperationException(string message) : base(message)
 	{
 	}
 
+	/// <summary>
+	/// Initializes a new instance of the <see cref="LdapOperationException"/> class with a message and inner exception.
+	/// </summary>
+	/// <param name="message">Error message.</param>
+	/// <param name="innerException">Underlying cause of this exception.</param>
 	public LdapOperationException(string message, Exception innerException) : base(message, innerException)
 	{
 	}

--- a/src/Bitai.LDAPHelper/QueryFilters/AttributeFilter.cs
+++ b/src/Bitai.LDAPHelper/QueryFilters/AttributeFilter.cs
@@ -1,18 +1,41 @@
-﻿using Bitai.LDAPHelper.DTO;
+using Bitai.LDAPHelper.DTO;
 
 namespace Bitai.LDAPHelper.QueryFilters
 {
+    /// <summary>
+    /// Represents a single LDAP attribute filter expression.
+    /// </summary>
     public class AttributeFilter : ICombinableFilter
     {
         private string _generatedFilterText = null;
 
 
+        /// <summary>
+        /// Gets the target LDAP attribute.
+        /// </summary>
         public EntryAttribute FilterAttribute { get; }
+
+        /// <summary>
+        /// Gets the filter value.
+        /// </summary>
         public FilterValue FilterValue { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether this filter is negated.
+        /// </summary>
         public bool IsFilterNegated { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the LDAP text has already been generated.
+        /// </summary>
         public bool Generated { get; private set; }
 
 
+        /// <summary>
+        /// Initializes a new non-negated attribute filter.
+        /// </summary>
+        /// <param name="filterAttribute">Target LDAP attribute.</param>
+        /// <param name="filterValue">Value for the attribute comparison.</param>
         public AttributeFilter(DTO.EntryAttribute filterAttribute, FilterValue filterValue)
         {
             FilterAttribute = filterAttribute;
@@ -20,6 +43,12 @@ namespace Bitai.LDAPHelper.QueryFilters
             IsFilterNegated = false;
         }
 
+        /// <summary>
+        /// Initializes a new attribute filter.
+        /// </summary>
+        /// <param name="isFilterNegated">Whether the generated filter is negated.</param>
+        /// <param name="filterAttribute">Target LDAP attribute.</param>
+        /// <param name="filterValue">Value for the attribute comparison.</param>
         public AttributeFilter(bool isFilterNegated, DTO.EntryAttribute filterAttribute, FilterValue filterValue) : this(filterAttribute, filterValue)
         {
             FilterAttribute = filterAttribute;
@@ -28,6 +57,10 @@ namespace Bitai.LDAPHelper.QueryFilters
         }
 
 
+        /// <summary>
+        /// Generates the LDAP filter text for this instance.
+        /// </summary>
+        /// <returns>LDAP filter expression.</returns>
         public override string ToString()
         {
             if (Generated)
@@ -46,6 +79,9 @@ namespace Bitai.LDAPHelper.QueryFilters
             return _generatedFilterText;
         }
 
+        /// <summary>
+        /// Resets generated-state so the filter text is rebuilt on next call.
+        /// </summary>
         public void Reset()
         {
             _generatedFilterText = null;

--- a/src/Bitai.LDAPHelper/QueryFilters/AttributeFilterCombiner.cs
+++ b/src/Bitai.LDAPHelper/QueryFilters/AttributeFilterCombiner.cs
@@ -1,12 +1,19 @@
-﻿using Bitai.LDAPHelper.DTO;
+using Bitai.LDAPHelper.DTO;
 using System.Collections.Generic;
 using System.Text;
 
 namespace Bitai.LDAPHelper.QueryFilters
 {
+    /// <summary>
+    /// Combines multiple LDAP filter components into a single LDAP expression.
+    /// </summary>
     public class AttributeFilterCombiner : List<ICombinableFilter>, ICombinableFilter
     {
         #region Static methods
+        /// <summary>
+        /// Creates a filter combiner that targets user entries and excludes computers and groups.
+        /// </summary>
+        /// <returns>A composed LDAP filter combiner.</returns>
         public static AttributeFilterCombiner CreateOnlyUsersFilterCombiner()
         {
             var noComputerFilter = new QueryFilters.AttributeFilter(true, EntryAttribute.objectClass, new QueryFilters.FilterValue("computer"));
@@ -18,6 +25,10 @@ namespace Bitai.LDAPHelper.QueryFilters
             return new QueryFilters.AttributeFilterCombiner(false, true, new List<QueryFilters.AttributeFilter> { noComputerFilter, noGroupFilter, userFilter });
         }
 
+        /// <summary>
+        /// Creates a filter combiner that targets group entries and excludes users and computers.
+        /// </summary>
+        /// <returns>A composed LDAP filter combiner.</returns>
         public static AttributeFilterCombiner CreateOnlyGroupsFilterCombiner()  
         {
             var noComputerFilter = new QueryFilters.AttributeFilter(true, EntryAttribute.objectClass, new QueryFilters.FilterValue("computer"));
@@ -34,29 +45,58 @@ namespace Bitai.LDAPHelper.QueryFilters
         private string _generatedFilterText = null;
 
 
+        /// <summary>
+        /// Gets or sets a value indicating whether the combined expression is negated.
+        /// </summary>
         public bool IsCombinerNegated { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether filters are combined conjunctively (AND) or disjunctively (OR).
+        /// </summary>
         public bool ConjunctiveFilters { get; set; }
+
+        /// <summary>
+        /// Gets a value indicating whether the LDAP text has already been generated.
+        /// </summary>
         public bool Generated { get; private set; }
 
 
+        /// <summary>
+        /// Initializes a new non-negated conjunctive combiner.
+        /// </summary>
         public AttributeFilterCombiner() : base()
         {
             IsCombinerNegated = false;
             ConjunctiveFilters = true;
         }
 
+        /// <summary>
+        /// Initializes a new combiner.
+        /// </summary>
+        /// <param name="isCombinerNegated">Whether the full expression is negated.</param>
+        /// <param name="conjunctiveFilters"><see langword="true"/> for AND-combination; <see langword="false"/> for OR-combination.</param>
         public AttributeFilterCombiner(bool isCombinerNegated, bool conjunctiveFilters) : this()
         {
             IsCombinerNegated = isCombinerNegated;
             ConjunctiveFilters = conjunctiveFilters;
         }
 
+        /// <summary>
+        /// Initializes a new combiner with initial filter components.
+        /// </summary>
+        /// <param name="isCombinerNegated">Whether the full expression is negated.</param>
+        /// <param name="conjunctiveFilters"><see langword="true"/> for AND-combination; <see langword="false"/> for OR-combination.</param>
+        /// <param name="filters">Initial filter components.</param>
         public AttributeFilterCombiner(bool isCombinerNegated, bool conjunctiveFilters, IEnumerable<ICombinableFilter> filters) : this(isCombinerNegated, conjunctiveFilters)
         {
             AddRange(filters);
         }
 
 
+        /// <summary>
+        /// Generates LDAP filter text for all contained filter components.
+        /// </summary>
+        /// <returns>LDAP filter expression.</returns>
         public override string ToString()
         {
             if (Generated)
@@ -99,6 +139,9 @@ namespace Bitai.LDAPHelper.QueryFilters
             }
         }
 
+        /// <summary>
+        /// Resets generated-state so filter text is rebuilt on next call.
+        /// </summary>
         public void Reset()
         {
             _generatedFilterText = null;

--- a/src/Bitai.LDAPHelper/QueryFilters/FilterValue.cs
+++ b/src/Bitai.LDAPHelper/QueryFilters/FilterValue.cs
@@ -1,12 +1,23 @@
-﻿using System;
+using System;
 
 namespace Bitai.LDAPHelper.QueryFilters
 {
+    /// <summary>
+    /// Represents a validated LDAP filter value.
+    /// </summary>
     public class FilterValue
     {
+        /// <summary>
+        /// Gets the raw value used in LDAP filters.
+        /// </summary>
         public string Value { get; }
 
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FilterValue"/> class.
+        /// </summary>
+        /// <param name="value">Filter value.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="value"/> is null, empty, or whitespace.</exception>
         public FilterValue(string value)
         {
             if (string.IsNullOrEmpty(value) || string.IsNullOrWhiteSpace(value))
@@ -16,6 +27,10 @@ namespace Bitai.LDAPHelper.QueryFilters
         }
 
 
+        /// <summary>
+        /// Returns the filter value text.
+        /// </summary>
+        /// <returns>The raw filter value.</returns>
         public override string ToString()
         {
             return Value;

--- a/src/Bitai.LDAPHelper/QueryFilters/ICombinableFilter.cs
+++ b/src/Bitai.LDAPHelper/QueryFilters/ICombinableFilter.cs
@@ -1,11 +1,24 @@
-﻿namespace Bitai.LDAPHelper.QueryFilters
+namespace Bitai.LDAPHelper.QueryFilters
 {
+    /// <summary>
+    /// Defines a filter component that can generate LDAP filter text and be combined with others.
+    /// </summary>
     public interface ICombinableFilter
     {
+        /// <summary>
+        /// Gets a value indicating whether the filter text has already been generated.
+        /// </summary>
         bool Generated { get; }
 
+        /// <summary>
+        /// Resets generated-state so filter text is rebuilt on next <see cref="ToString"/> call.
+        /// </summary>
         void Reset();
 
+        /// <summary>
+        /// Generates LDAP filter text.
+        /// </summary>
+        /// <returns>LDAP filter expression.</returns>
         string ToString();
     }
 }

--- a/src/Bitai.LDAPHelper/SearchLimits.cs
+++ b/src/Bitai.LDAPHelper/SearchLimits.cs
@@ -2,6 +2,9 @@ using Bitai.LDAPHelper.LdapAdapters;
 
 namespace Bitai.LDAPHelper
 {
+    /// <summary>
+    /// Represents LDAP search boundaries and server limits.
+    /// </summary>
     public class SearchLimits : ISearchLimits
     {
         /// <summary>
@@ -28,6 +31,10 @@ namespace Bitai.LDAPHelper
         /// </summary>
         public int MaxSearchTimeout { get; set; } = 60;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SearchLimits"/> class.
+        /// </summary>
+        /// <param name="baseDN">Base distinguished name to use for searches.</param>
         public SearchLimits(string baseDN)
         {
             this.BaseDN = baseDN;

--- a/src/Bitai.LDAPHelper/Searcher.cs
+++ b/src/Bitai.LDAPHelper/Searcher.cs
@@ -8,13 +8,28 @@ using Novell.Directory.Ldap;
 
 namespace Bitai.LDAPHelper
 {
+    /// <summary>
+    /// Performs LDAP search operations and maps results into DTO models.
+    /// </summary>
 	public class Searcher : BaseHelper
 	{
 		#region Constructor 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Searcher"/> class.
+        /// </summary>
+        /// <param name="clientConfiguration">Client configuration containing connection, credential, and search settings.</param>
+        /// <param name="connectionFactory">LDAP connection factory abstraction.</param>
 		public Searcher(ClientConfiguration clientConfiguration, ILdapConnectionFactoryAdapter connectionFactory) : base(clientConfiguration, connectionFactory)
 		{
 		}
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Searcher"/> class.
+        /// </summary>
+        /// <param name="connectionInfo">LDAP server connection settings.</param>
+        /// <param name="searchLimits">LDAP search limits.</param>
+        /// <param name="domainAccountCredential">Credential used to execute LDAP searches.</param>
+        /// <param name="connectionFactory">LDAP connection factory abstraction.</param>
 		public Searcher(ConnectionInfo connectionInfo, SearchLimits searchLimits, DTO.LDAPDomainAccountCredential domainAccountCredential, ILdapConnectionFactoryAdapter connectionFactory) : base(connectionInfo, searchLimits, domainAccountCredential, connectionFactory)
 		{
 		}
@@ -27,7 +42,7 @@ namespace Bitai.LDAPHelper
 		/// <summary>
 		/// Searches for entries matching the provided LDAP filter and loads the requested attributes.
 		/// </summary>
-		/// <param name="searchFilter">
+        /// <param name="searchFilterObject">
 		/// A combinable LDAP filter that identifies the entries to search for. This filter will be converted 
 		/// to its string representation and used directly in the LDAP search operation.
 		/// </param>

--- a/tests/Bitai.LDAPHelper.Tests.Mocks/Bitai.LDAPHelper.Tests.Mocks.csproj
+++ b/tests/Bitai.LDAPHelper.Tests.Mocks/Bitai.LDAPHelper.Tests.Mocks.csproj
@@ -4,9 +4,9 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-	 <Version>10.1.0</Version>
-    <AssemblyVersion>10.1.0</AssemblyVersion>
-	 <FileVersion>10.1.0</FileVersion> 
+	 <Version>10.1.1</Version>
+    <AssemblyVersion>10.1.1</AssemblyVersion>
+	 <FileVersion>10.1.1</FileVersion> 
 	 <Authors>Viko Bastidas (BITAI)</Authors>
 	 <Copyright>© 2026 BITAI. MIT License.</Copyright>
 	 <RepositoryUrl>https://github.com/bitai-cs/LDAPHelper.git</RepositoryUrl>

--- a/tests/Bitai.LDAPHelper.Tests.Mocks/LdapAdapters/MockLdapAttributeSetAdapter.cs
+++ b/tests/Bitai.LDAPHelper.Tests.Mocks/LdapAdapters/MockLdapAttributeSetAdapter.cs
@@ -1,7 +1,10 @@
-﻿using Bitai.LDAPHelper.LdapAdapters;
+using Bitai.LDAPHelper.LdapAdapters;
 
 namespace Bitai.LDAPHelper.Tests.Mocks.LdapAdapters;
 
+/// <summary>
+/// In-memory mock implementation of <see cref="ILdapAttributeSetAdapter"/> for tests.
+/// </summary>
 public class MockLdapAttributeSetAdapter : ILdapAttributeSetAdapter
 {
     private Dictionary<string, MockLdapAttributeAdapter> _attributeDictionary = new();

--- a/tests/Bitai.LDAPHelper.Tests.Mocks/LdapAdapters/MockLdapConnectionAdapter.cs
+++ b/tests/Bitai.LDAPHelper.Tests.Mocks/LdapAdapters/MockLdapConnectionAdapter.cs
@@ -3,6 +3,9 @@ using Bitai.LDAPHelper.DTO;
 
 namespace Bitai.LDAPHelper.Tests.Mocks.LdapAdapters;
 
+/// <summary>
+/// In-memory mock LDAP connection used by tests to simulate bind/search/add/modify/delete operations.
+/// </summary>
 public class MockLdapConnectionAdapter : ILdapConnectionAdapter
 {
     private bool _disposed = false;

--- a/tests/Bitai.LDAPHelper.Tests.Mocks/LdapAdapters/MockLdapConnectionFactoryAdapter.cs
+++ b/tests/Bitai.LDAPHelper.Tests.Mocks/LdapAdapters/MockLdapConnectionFactoryAdapter.cs
@@ -2,6 +2,9 @@ using Bitai.LDAPHelper.LdapAdapters;
 
 namespace Bitai.LDAPHelper.Tests.Mocks.LdapAdapters;
 
+/// <summary>
+/// Mock implementation of <see cref="ILdapConnectionFactoryAdapter"/> that returns a provided mock connection.
+/// </summary>
 public class MockLdapConnectionFactoryAdapter : ILdapConnectionFactoryAdapter
 {
     private readonly MockLdapConnectionAdapter _connection;

--- a/tests/Bitai.LDAPHelper.Tests.Mocks/LdapAdapters/MockLdapEntryAdapter.cs
+++ b/tests/Bitai.LDAPHelper.Tests.Mocks/LdapAdapters/MockLdapEntryAdapter.cs
@@ -1,7 +1,10 @@
-﻿using Bitai.LDAPHelper.LdapAdapters;
+using Bitai.LDAPHelper.LdapAdapters;
 
 namespace Bitai.LDAPHelper.Tests.Mocks.LdapAdapters;
 
+/// <summary>
+/// In-memory mock LDAP entry used by test scenarios.
+/// </summary>
 public class MockLdapEntryAdapter : ILdapEntryAdapter
 {
     private readonly MockLdapAttributeSetAdapter _attributeSet;

--- a/tests/Bitai.LDAPHelper.Tests.Mocks/LdapAdapters/MockLdapMessageAdapter.cs
+++ b/tests/Bitai.LDAPHelper.Tests.Mocks/LdapAdapters/MockLdapMessageAdapter.cs
@@ -1,7 +1,10 @@
-﻿using Bitai.LDAPHelper.LdapAdapters;
+using Bitai.LDAPHelper.LdapAdapters;
 
 namespace Bitai.LDAPHelper.Tests.Mocks.LdapAdapters;
 
+/// <summary>
+/// In-memory mock LDAP message wrapper used in search queue responses.
+/// </summary>
 public class MockLdapMessageAdapter : ILdapMessageAdapter
 {
     public MockLdapMessageAdapter(ILdapEntryAdapter entry) {

--- a/tests/Bitai.LDAPHelper.Tests.Mocks/LdapAdapters/MockLdapModificationAdapter.cs
+++ b/tests/Bitai.LDAPHelper.Tests.Mocks/LdapAdapters/MockLdapModificationAdapter.cs
@@ -1,7 +1,10 @@
-﻿using Bitai.LDAPHelper.LdapAdapters;
+using Bitai.LDAPHelper.LdapAdapters;
 
 namespace Bitai.LDAPHelper.Tests.Mocks.LdapAdapters;
 
+/// <summary>
+/// In-memory mock implementation of <see cref="ILdapModificationAdapter"/>.
+/// </summary>
 public class MockLdapModificationAdapter : ILdapModificationAdapter
 {
     public MockLdapModificationAdapter(LdapModificationType type, string attributeName, object value) {
@@ -16,6 +19,9 @@ public class MockLdapModificationAdapter : ILdapModificationAdapter
     public ILdapAttributeAdapter Attribute => new MockLdapAttributeAdapter(AttributeName, Value);
 }
 
+/// <summary>
+/// Simple DTO used to capture applied modifications in mock connection state.
+/// </summary>
 public class MockModification
 {
     public string DistinguishedName { get; set; }

--- a/tests/Bitai.LDAPHelper.Tests.Mocks/LdapAdapters/MockLdapPersistentConnectionAdapter.cs
+++ b/tests/Bitai.LDAPHelper.Tests.Mocks/LdapAdapters/MockLdapPersistentConnectionAdapter.cs
@@ -4,6 +4,9 @@ using Bitai.LDAPHelper.Tests.Mocks.LdapData;
 
 namespace Bitai.LDAPHelper.Tests.Mocks.LdapAdapters;
 
+/// <summary>
+/// Persistent mock connection backed by a shared in-memory LDAP data store.
+/// </summary>
 public class MockLdapPersistentConnectionAdapter : MockLdapConnectionAdapter
 {
     private readonly MockLdapDataStore _dataStore;

--- a/tests/Bitai.LDAPHelper.Tests.Mocks/LdapAdapters/MockLdapPersistentConnectionFactoryAdapter.cs
+++ b/tests/Bitai.LDAPHelper.Tests.Mocks/LdapAdapters/MockLdapPersistentConnectionFactoryAdapter.cs
@@ -2,6 +2,9 @@ using Bitai.LDAPHelper.LdapAdapters;
 
 namespace Bitai.LDAPHelper.Tests.Mocks.LdapAdapters;
 
+/// <summary>
+/// Factory for creating persistent mock LDAP connections backed by shared in-memory data.
+/// </summary>
 public class MockLdapPersistentConnectionFactoryAdapter : ILdapConnectionFactoryAdapter
 {
     private readonly MockLdapPersistentConnectionAdapter _connection;

--- a/tests/Bitai.LDAPHelper.Tests.Mocks/LdapAdapters/MockLdapSearchQueueAdapter.cs
+++ b/tests/Bitai.LDAPHelper.Tests.Mocks/LdapAdapters/MockLdapSearchQueueAdapter.cs
@@ -1,7 +1,10 @@
-﻿using Bitai.LDAPHelper.LdapAdapters;
+using Bitai.LDAPHelper.LdapAdapters;
 
 namespace Bitai.LDAPHelper.Tests.Mocks.LdapAdapters;
 
+/// <summary>
+/// In-memory mock implementation of <see cref="ILdapSearchQueueAdapter"/>.
+/// </summary>
 public class MockLdapSearchQueueAdapter : ILdapSearchQueueAdapter
 {
     private Queue<ILdapMessageAdapter> _messages = new();

--- a/tests/Bitai.LDAPHelper.Tests.Mocks/LdapData/MockLdapDataSeeder.cs
+++ b/tests/Bitai.LDAPHelper.Tests.Mocks/LdapData/MockLdapDataSeeder.cs
@@ -3,6 +3,9 @@ using Microsoft.Extensions.Logging;
 
 namespace Bitai.LDAPHelper.Tests.Mocks.LdapData;
 
+/// <summary>
+/// Seeds deterministic mock LDAP data for integration-style tests and demos.
+/// </summary>
 public class MockLdapDataSeeder
 {
     private readonly MockLdapDataStore _dataStore;

--- a/tests/Bitai.LDAPHelper.Tests.Mocks/LdapData/MockLdapDataStore.cs
+++ b/tests/Bitai.LDAPHelper.Tests.Mocks/LdapData/MockLdapDataStore.cs
@@ -2,6 +2,9 @@ using Bitai.LDAPHelper.Tests.Mocks.LdapAdapters;
 
 namespace Bitai.LDAPHelper.Tests.Mocks.LdapData;
 
+/// <summary>
+/// Thread-safe in-memory LDAP entry store used by persistent mock adapters.
+/// </summary>
 public class MockLdapDataStore
 {
     private static readonly Lazy<MockLdapDataStore> _instance = new Lazy<MockLdapDataStore>(() => new MockLdapDataStore());

--- a/tests/Bitai.LDAPHelper.Tests/AccountManagerAdapterTests.cs
+++ b/tests/Bitai.LDAPHelper.Tests/AccountManagerAdapterTests.cs
@@ -3,6 +3,9 @@ using Bitai.LDAPHelper.Tests.Mocks.LdapAdapters;
 
 namespace Bitai.LDAPHelper.Tests
 {
+    /// <summary>
+    /// Integration-style unit tests for <see cref="AccountManager"/> using mock LDAP adapters.
+    /// </summary>
     public class AccountManagerAdapterTests: BaseTests
     {
         [Fact]

--- a/tests/Bitai.LDAPHelper.Tests/AuthenticatorAdapterTests.cs
+++ b/tests/Bitai.LDAPHelper.Tests/AuthenticatorAdapterTests.cs
@@ -1,8 +1,11 @@
-﻿using Bitai.LDAPHelper.DTO;
+using Bitai.LDAPHelper.DTO;
 using Bitai.LDAPHelper.Tests.Mocks.LdapAdapters;
 
 namespace Bitai.LDAPHelper.Tests
 {
+    /// <summary>
+    /// Integration-style unit tests for <see cref="Authenticator"/> using mock LDAP adapters.
+    /// </summary>
     public class AuthenticatorAdapterTests : BaseTests
     {
         [Fact]

--- a/tests/Bitai.LDAPHelper.Tests/BaseTests.cs
+++ b/tests/Bitai.LDAPHelper.Tests/BaseTests.cs
@@ -1,7 +1,10 @@
-﻿using Bitai.LDAPHelper.Tests.Mocks.LdapAdapters;
+using Bitai.LDAPHelper.Tests.Mocks.LdapAdapters;
 
 namespace Bitai.LDAPHelper.Tests
 {
+    /// <summary>
+    /// Shared test-fixture helpers for LDAP helper test suites.
+    /// </summary>
     public class BaseTests
     {
         public MockLdapEntryAdapter CreateMockUserEntry(string firstName, string lastName, SearchLimits? searchLimits, out QueryFilters.AttributeFilter searchFilterSAMAccountName, out QueryFilters.AttributeFilter searchFilterDistinguishedName, string[] memberOfDistinguishedNames = null, string groupName = null, string groupContainerName = null) {

--- a/tests/Bitai.LDAPHelper.Tests/Bitai.LDAPHelper.Tests.csproj
+++ b/tests/Bitai.LDAPHelper.Tests/Bitai.LDAPHelper.Tests.csproj
@@ -7,9 +7,9 @@
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
-    <AssemblyVersion>10.1.2</AssemblyVersion>
-    <FileVersion>10.1.2</FileVersion>
-    <Version>10.1.2</Version>
+    <AssemblyVersion>10.1.3</AssemblyVersion>
+    <FileVersion>10.1.3</FileVersion>
+    <Version>10.1.3</Version>
     <UserSecretsId>5981b6a0-6b9e-439d-8324-a0ef8bfd0f11</UserSecretsId>
   </PropertyGroup>
 

--- a/tests/Bitai.LDAPHelper.Tests/GroupMembershipValidatorTests.cs
+++ b/tests/Bitai.LDAPHelper.Tests/GroupMembershipValidatorTests.cs
@@ -3,6 +3,9 @@ using Bitai.LDAPHelper.Tests.Mocks.LdapAdapters;
 
 namespace Bitai.LDAPHelper.Tests
 {
+    /// <summary>
+    /// Unit tests for <see cref="GroupMembershipValidator"/> using mock LDAP adapters.
+    /// </summary>
     public class GroupMembershipValidatorTests : BaseTests
     {
         private readonly ConnectionInfo _validConnectionInfo;

--- a/tests/Bitai.LDAPHelper.Tests/SearcherAdapterTests.cs
+++ b/tests/Bitai.LDAPHelper.Tests/SearcherAdapterTests.cs
@@ -3,6 +3,9 @@ using Bitai.LDAPHelper.Tests.Mocks.LdapAdapters;
 
 namespace Bitai.LDAPHelper.Tests
 {
+    /// <summary>
+    /// Integration-style unit tests for <see cref="Searcher"/> using mock LDAP adapters.
+    /// </summary>
     public class SearcherAdapterTests : BaseTests
     {
         [Fact]


### PR DESCRIPTION
XML docs updated on all projects.

## Summary

Add comprehensive XML documentation across LDAP helper core classes, DTOs, adapters, demo utilities, and tests to clarify responsibilities, parameters, and result semantics.

Enhancements:
- Clarify the meaning and usage of request labels, search limits, and identifier attributes in public APIs through XML docs.

Documentation:
- Document LDAP DTO models, credentials, result types, and helper services to describe LDAP workflows and data semantics.
- Add XML docs to LDAP adapter interfaces, Novell implementations, and mock adapters to explain usage patterns and behaviors.
- Annotate demo configuration and context classes with XML comments describing their role in running sample scenarios.
- Extend XML comments on test fixtures and adapter tests to clarify their purpose and coverage.
- Improve inline documentation for LDAP search, filter, connection, and account management utilities, including exceptions and enums.